### PR TITLE
docs: add AI agent skill install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ Comprehensive SDKs, detailed documentation, and responsive support. Ship faster 
 
 ---
 
+## Install via AI Agent Skill
+
+![skills.sh](https://skills.sh/b/TurboDocx/quickstart)
+
+Install the TurboDocx SDKs in a single prompt using the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart) — works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents.
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Two skills are included:
+
+| Skill | What it does |
+|-------|-------------|
+| `turbodocx` | Scaffolds document generation in your project — picks the right SDK for your language, installs it, and writes a working code example |
+| `turbodocx-html-to-docx` | Installs and configures `@turbodocx/html-to-docx` (open-source HTML → DOCX converter) |
+
+> **Prefer manual install?** Jump straight to [Available SDKs](#available-sdks) below.
+
+---
+
 ## Available SDKs
 
 | Language | Package | Install | Registry |

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Comprehensive SDKs, detailed documentation, and responsive support. Ship faster 
 
 ## Install via AI Agent Skill
 
-![skills.sh](https://skills.sh/b/TurboDocx/quickstart)
-
 Install the TurboDocx SDKs in a single prompt using the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart) — works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents.
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds an **Install via AI Agent Skill** section above `## Available SDKs`
- Includes `npx skills add TurboDocx/quickstart` install command
- Skills.sh badge displayed as image (no link) until the skill is indexed on skills.sh
- Links to `https://github.com/TurboDocx/quickstart`
- Table describing both included skills (`turbodocx` and `turbodocx-html-to-docx`)

## Notes

Keep as draft until:
1. skills.sh registers the skill (then wrap the badge in a link)
2. Launch day

🤖 Generated with [Claude Code](https://claude.com/claude-code)