### PR TITLE
docs: add agent skill install section to package READMEs

### DIFF
--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -64,6 +64,18 @@ go get github.com/turbodocx/sdk
 
 ---
 
+## Install via AI Agent Skill
+
+Let an AI coding agent set up this SDK for you with the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart):
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents. The skill detects your language, installs the package, and generates working integration code.
+
+---
+
 ## Quick Start
 
 ```go

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -83,6 +83,18 @@ implementation("com.turbodocx:turbodocx-sdk:0.2.0")
 
 ---
 
+## Install via AI Agent Skill
+
+Let an AI coding agent set up this SDK for you with the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart):
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents. The skill detects your language, installs the package, and generates working integration code.
+
+---
+
 ## Quick Start
 
 ```java

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -80,6 +80,18 @@ bun add @turbodocx/sdk
 
 ---
 
+## Install via AI Agent Skill
+
+Let an AI coding agent set up this SDK for you with the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart):
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents. The skill detects your language, installs the package, and generates working integration code.
+
+---
+
 ## Quick Start
 
 ```typescript

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -68,6 +68,18 @@ composer require turbodocx/sdk
 
 ---
 
+## Install via AI Agent Skill
+
+Let an AI coding agent set up this SDK for you with the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart):
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents. The skill detects your language, installs the package, and generates working integration code.
+
+---
+
 ## Quick Start
 
 ```php

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -78,6 +78,18 @@ conda install -c conda-forge turbodocx-sdk
 
 ---
 
+## Install via AI Agent Skill
+
+Let an AI coding agent set up this SDK for you with the [TurboDocx Quickstart Agent Skill](https://github.com/TurboDocx/quickstart):
+
+```bash
+npx skills add TurboDocx/quickstart
+```
+
+Works with Claude Code, GitHub Copilot, Cursor, OpenCode, and other AI coding agents. The skill detects your language, installs the package, and generates working integration code.
+
+---
+
 ## Quick Start
 
 ### Async (Recommended)


### PR DESCRIPTION
## Summary

Adds an **Install via AI Agent Skill** section to the README of every SDK package (JS/TS, Python, Go, PHP, Java), placed between `## Installation` and `## Quick Start`.

- `packages/js-sdk/README.md`
- `packages/py-sdk/README.md`
- `packages/go-sdk/README.md`
- `packages/php-sdk/README.md`
- `packages/java-sdk/README.md`

Each section promotes `npx skills add TurboDocx/quickstart` and links to https://github.com/TurboDocx/quickstart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)