### PR TITLE
test(partner): partner webhook provisioning test suites across SDKs (WIP)

### DIFF
--- a/packages/go-sdk/turbopartner_webhooks_test.go
+++ b/packages/go-sdk/turbopartner_webhooks_test.go
@@ -1,0 +1,305 @@
+package turbodocx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================
+// Webhook Management Tests
+// =============================================
+
+func TestCreateWebhook(t *testing.T) {
+	t.Run("creates webhook successfully", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks", r.URL.Path)
+			assert.Equal(t, "Bearer TDXP-test-key", r.Header.Get("Authorization"))
+
+			var body CreateWebhookRequest
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "my-signing-webhook", body.Name)
+			assert.Equal(t, []string{"https://example.com/hook"}, body.URLs)
+			assert.Equal(t, []string{"signature.document.completed"}, body.Events)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"id":     "webhook-uuid-789",
+					"name":   "my-signing-webhook",
+					"urls":   []string{"https://example.com/hook"},
+					"events": []string{"signature.document.completed"},
+					"secret": "whsec_abc123",
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.CreateWebhook(context.Background(), "org-uuid-456", &CreateWebhookRequest{
+			Name:   "my-signing-webhook",
+			URLs:   []string{"https://example.com/hook"},
+			Events: []string{"signature.document.completed"},
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, "my-signing-webhook", result.Data.Name)
+		assert.NotEmpty(t, result.Data.Secret)
+	})
+
+	t.Run("returns auth error on 401", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Unauthorized"})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		_, err := client.CreateWebhook(context.Background(), "org-uuid-456", &CreateWebhookRequest{
+			Name:   "webhook",
+			URLs:   []string{"https://example.com/hook"},
+			Events: []string{"signature.document.completed"},
+		})
+
+		require.Error(t, err)
+		authErr, ok := err.(*AuthenticationError)
+		require.True(t, ok, "expected AuthenticationError")
+		assert.NotNil(t, authErr)
+	})
+}
+
+func TestListWebhooks(t *testing.T) {
+	t.Run("lists webhooks with pagination", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks", r.URL.Path)
+			assert.Equal(t, "10", r.URL.Query().Get("limit"))
+			assert.Equal(t, "0", r.URL.Query().Get("offset"))
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"results":      []map[string]interface{}{{"id": "webhook-1", "name": "my-webhook"}},
+					"totalRecords": 1,
+					"limit":        10,
+					"offset":       0,
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.ListWebhooks(context.Background(), "org-uuid-456", &ListWebhooksRequest{
+			Limit:  IntPtr(10),
+			Offset: IntPtr(0),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, 1, result.Data.TotalRecords)
+		assert.Len(t, result.Data.Results, 1)
+	})
+
+	t.Run("lists webhooks without params", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"results": []interface{}{}, "totalRecords": 0, "limit": 50, "offset": 0,
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.ListWebhooks(context.Background(), "org-uuid-456", nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+	})
+}
+
+func TestGetWebhook(t *testing.T) {
+	t.Run("gets webhook by name", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks/my-signing-webhook", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data":    map[string]interface{}{"id": "webhook-uuid-789", "name": "my-signing-webhook"},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.GetWebhook(context.Background(), "org-uuid-456", "my-signing-webhook")
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, "my-signing-webhook", result.Data.Name)
+	})
+
+	t.Run("returns not found error on 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Not Found"})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		_, err := client.GetWebhook(context.Background(), "org-uuid-456", "nonexistent")
+
+		require.Error(t, err)
+		notFoundErr, ok := err.(*NotFoundError)
+		require.True(t, ok, "expected NotFoundError")
+		assert.NotNil(t, notFoundErr)
+	})
+}
+
+func TestUpdateWebhook(t *testing.T) {
+	t.Run("updates webhook fields", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "PATCH", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks/my-signing-webhook", r.URL.Path)
+
+			var body UpdateWebhookRequest
+			json.NewDecoder(r.Body).Decode(&body)
+			require.NotNil(t, body.IsActive)
+			assert.False(t, *body.IsActive)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data":    map[string]interface{}{"id": "webhook-uuid-789", "name": "my-signing-webhook", "isActive": false},
+			})
+		}))
+		defer server.Close()
+
+		isActive := false
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.UpdateWebhook(context.Background(), "org-uuid-456", "my-signing-webhook", &UpdateWebhookRequest{
+			IsActive: &isActive,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.False(t, result.Data.IsActive)
+	})
+}
+
+func TestDeleteWebhook(t *testing.T) {
+	t.Run("deletes webhook successfully", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "DELETE", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks/my-signing-webhook", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"message": "Webhook deleted",
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.DeleteWebhook(context.Background(), "org-uuid-456", "my-signing-webhook")
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+	})
+}
+
+func TestTestWebhook(t *testing.T) {
+	t.Run("sends test event with no overrides", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks/my-signing-webhook/test", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"deliveries": []interface{}{},
+					"summary":    map[string]interface{}{"total": 1, "successful": 1, "failed": 0, "errors": []interface{}{}},
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.TestWebhook(context.Background(), "org-uuid-456", "my-signing-webhook", nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, 1, result.Data.Summary.Successful)
+	})
+
+	t.Run("sends test event with event override", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body TestWebhookRequest
+			json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "signature.document.voided", body.Event)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"deliveries": []interface{}{},
+					"summary":    map[string]interface{}{"total": 1, "successful": 1, "failed": 0, "errors": []interface{}{}},
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.TestWebhook(context.Background(), "org-uuid-456", "my-signing-webhook", &TestWebhookRequest{
+			Event: "signature.document.voided",
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+	})
+}
+
+func TestListWebhookDeliveries(t *testing.T) {
+	t.Run("lists deliveries with pagination", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/orgs/org-uuid-456/webhooks/my-signing-webhook/deliveries", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"results": []map[string]interface{}{
+						{"id": "del-1", "event": "signature.document.completed", "statusCode": 200},
+					},
+					"totalRecords": 1,
+					"limit":        50,
+					"offset":       0,
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.ListWebhookDeliveries(context.Background(), "org-uuid-456", "my-signing-webhook", nil)
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.Equal(t, 1, result.Data.TotalRecords)
+		assert.Len(t, result.Data.Results, 1)
+	})
+}

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerWebhooksTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerWebhooksTest.java
@@ -1,0 +1,376 @@
+package com.turbodocx;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TurboPartner Webhook Management Tests
+ *
+ * Tests for webhook provisioning operations:
+ * - createWebhook
+ * - listWebhooks
+ * - getWebhook
+ * - updateWebhook
+ * - deleteWebhook
+ * - testWebhook
+ * - listWebhookDeliveries
+ */
+class TurboPartnerWebhooksTest {
+
+    private MockWebServer server;
+    private TurboPartnerClient client;
+    private final Gson gson = new Gson();
+
+    private static final String PARTNER_ID = "test-partner-id";
+    private static final String ORG_ID = "org-uuid-456";
+    private static final String WEBHOOK_NAME = "my-signing-webhook";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = new MockWebServer();
+        server.start();
+
+        client = new TurboPartnerClient.Builder()
+                .partnerApiKey("TDXP-test-key")
+                .partnerId(PARTNER_ID)
+                .baseUrl(server.url("/").toString())
+                .build();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        server.shutdown();
+    }
+
+    // ============================================
+    // createWebhook
+    // ============================================
+
+    @Test
+    @DisplayName("should create a webhook and return result with secret")
+    void createWebhookSuccess() throws Exception {
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("id", "webhook-uuid-789");
+        responseData.addProperty("name", WEBHOOK_NAME);
+        responseData.addProperty("isActive", true);
+        responseData.addProperty("secret", "whsec_abc123");
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().createWebhook(
+                ORG_ID,
+                WEBHOOK_NAME,
+                List.of("https://example.com/hook"),
+                List.of("signature.document.completed"),
+                null
+        );
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks", request.getPath());
+        assertEquals("Bearer TDXP-test-key", request.getHeader("Authorization"));
+
+        assertTrue((Boolean) result.get("success"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> data = (Map<String, Object>) result.get("data");
+        assertEquals(WEBHOOK_NAME, data.get("name"));
+        assertEquals("whsec_abc123", data.get("secret"));
+    }
+
+    @Test
+    @DisplayName("should throw AuthenticationException on 401")
+    void createWebhookUnauthorized() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(401)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":\"Unauthorized\"}"));
+
+        assertThrows(TurboDocxException.AuthenticationException.class, () ->
+                client.turboPartner().createWebhook(
+                        ORG_ID, WEBHOOK_NAME,
+                        List.of("https://example.com/hook"),
+                        List.of("signature.document.completed"),
+                        null
+                ));
+    }
+
+    // ============================================
+    // listWebhooks
+    // ============================================
+
+    @Test
+    @DisplayName("should list webhooks with pagination")
+    void listWebhooksWithPagination() throws Exception {
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("totalRecords", 1);
+        responseData.addProperty("limit", 10);
+        responseData.addProperty("offset", 0);
+        responseData.add("results", gson.toJsonTree(List.of(
+                Map.of("id", "wh-1", "name", WEBHOOK_NAME)
+        )));
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().listWebhooks(ORG_ID, 10, 0, null);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("GET", request.getMethod());
+        assertTrue(request.getPath().startsWith("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks"));
+        assertTrue(request.getPath().contains("limit=10"));
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    @Test
+    @DisplayName("should list webhooks without params")
+    void listWebhooksNoParams() throws Exception {
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("totalRecords", 0);
+        responseData.addProperty("limit", 50);
+        responseData.addProperty("offset", 0);
+        responseData.add("results", gson.toJsonTree(List.of()));
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().listWebhooks(ORG_ID, null, null, null);
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    // ============================================
+    // getWebhook
+    // ============================================
+
+    @Test
+    @DisplayName("should get webhook by name")
+    void getWebhookByName() throws Exception {
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("id", "webhook-uuid-789");
+        responseData.addProperty("name", WEBHOOK_NAME);
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().getWebhook(ORG_ID, WEBHOOK_NAME);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("GET", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks/" + WEBHOOK_NAME, request.getPath());
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException on 404")
+    void getWebhookNotFound() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":\"Not Found\"}"));
+
+        assertThrows(TurboDocxException.NotFoundException.class, () ->
+                client.turboPartner().getWebhook(ORG_ID, "nonexistent"));
+    }
+
+    // ============================================
+    // updateWebhook
+    // ============================================
+
+    @Test
+    @DisplayName("should update webhook isActive field")
+    void updateWebhookIsActive() throws Exception {
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("id", "webhook-uuid-789");
+        responseData.addProperty("name", WEBHOOK_NAME);
+        responseData.addProperty("isActive", false);
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> updates = new HashMap<>();
+        updates.put("isActive", false);
+
+        Map<String, Object> result = client.turboPartner().updateWebhook(ORG_ID, WEBHOOK_NAME, updates);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("PATCH", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks/" + WEBHOOK_NAME, request.getPath());
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    // ============================================
+    // deleteWebhook
+    // ============================================
+
+    @Test
+    @DisplayName("should delete webhook successfully")
+    void deleteWebhookSuccess() throws Exception {
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.addProperty("message", "Webhook deleted");
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().deleteWebhook(ORG_ID, WEBHOOK_NAME);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("DELETE", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks/" + WEBHOOK_NAME, request.getPath());
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    // ============================================
+    // testWebhook
+    // ============================================
+
+    @Test
+    @DisplayName("should send test event and return delivery summary")
+    void testWebhookDefault() throws Exception {
+        JsonObject summary = new JsonObject();
+        summary.addProperty("total", 1);
+        summary.addProperty("successful", 1);
+        summary.addProperty("failed", 0);
+        summary.add("errors", gson.toJsonTree(List.of()));
+
+        JsonObject responseData = new JsonObject();
+        responseData.add("deliveries", gson.toJsonTree(List.of()));
+        responseData.add("summary", summary);
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().testWebhook(ORG_ID, WEBHOOK_NAME, null);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("POST", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks/" + WEBHOOK_NAME + "/test", request.getPath());
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    @Test
+    @DisplayName("should pass event override to test endpoint")
+    void testWebhookWithEventOverride() throws Exception {
+        JsonObject summary = new JsonObject();
+        summary.addProperty("total", 1);
+        summary.addProperty("successful", 1);
+        summary.addProperty("failed", 0);
+        summary.add("errors", gson.toJsonTree(List.of()));
+
+        JsonObject responseData = new JsonObject();
+        responseData.add("deliveries", gson.toJsonTree(List.of()));
+        responseData.add("summary", summary);
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> overrides = new HashMap<>();
+        overrides.put("event", "signature.document.voided");
+
+        Map<String, Object> result = client.turboPartner().testWebhook(ORG_ID, WEBHOOK_NAME, overrides);
+
+        RecordedRequest request = server.takeRequest();
+        String body = request.getBody().readUtf8();
+        assertTrue(body.contains("signature.document.voided"));
+
+        assertTrue((Boolean) result.get("success"));
+    }
+
+    // ============================================
+    // listWebhookDeliveries
+    // ============================================
+
+    @Test
+    @DisplayName("should list webhook deliveries with pagination")
+    void listWebhookDeliveries() throws Exception {
+        JsonObject delivery = new JsonObject();
+        delivery.addProperty("id", "del-1");
+        delivery.addProperty("event", "signature.document.completed");
+        delivery.addProperty("statusCode", 200);
+
+        JsonObject responseData = new JsonObject();
+        responseData.addProperty("totalRecords", 1);
+        responseData.addProperty("limit", 50);
+        responseData.addProperty("offset", 0);
+        responseData.add("results", gson.toJsonTree(List.of(gson.fromJson(delivery, Map.class))));
+
+        JsonObject response = new JsonObject();
+        response.addProperty("success", true);
+        response.add("data", responseData);
+
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(gson.toJson(response)));
+
+        Map<String, Object> result = client.turboPartner().listWebhookDeliveries(ORG_ID, WEBHOOK_NAME, null, null);
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("GET", request.getMethod());
+        assertEquals(
+                "/partner/" + PARTNER_ID + "/orgs/" + ORG_ID + "/webhooks/" + WEBHOOK_NAME + "/deliveries",
+                request.getPath()
+        );
+
+        assertTrue((Boolean) result.get("success"));
+    }
+}

--- a/packages/js-sdk/tests/partner-webhooks.test.ts
+++ b/packages/js-sdk/tests/partner-webhooks.test.ts
@@ -1,0 +1,370 @@
+/**
+ * TurboPartner Webhook Management Tests
+ *
+ * Tests for webhook provisioning operations:
+ * - createWebhook
+ * - listWebhooks
+ * - getWebhook
+ * - updateWebhook
+ * - deleteWebhook
+ * - testWebhook
+ * - listWebhookDeliveries
+ */
+
+import { TurboPartner } from "../src/modules/partner";
+import { HttpClient } from "../src/http";
+
+// Mock the HttpClient
+jest.mock("../src/http");
+
+const MockedHttpClient = HttpClient as jest.MockedClass<typeof HttpClient>;
+
+const PARTNER_ID = "partner-uuid-123";
+const PARTNER_API_KEY = "TDXP-test-key-123";
+const ORG_ID = "org-uuid-456";
+const WEBHOOK_NAME = "my-signing-webhook";
+
+/** Reset static state and reconfigure TurboPartner */
+function setup() {
+  (TurboPartner as any).client = undefined;
+  (TurboPartner as any).partnerId = undefined;
+  TurboPartner.configure({
+    partnerApiKey: PARTNER_API_KEY,
+    partnerId: PARTNER_ID,
+  });
+}
+
+const mockWebhook = {
+  id: "webhook-uuid-789",
+  name: WEBHOOK_NAME,
+  urls: ["https://example.com/hook"],
+  events: ["signature.document.completed"],
+  isActive: true,
+  createdOn: "2025-01-01T00:00:00.000Z",
+  updatedOn: "2025-01-01T00:00:00.000Z",
+};
+
+describe("TurboPartner Webhook Management", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (TurboPartner as any).client = undefined;
+    (TurboPartner as any).partnerId = undefined;
+  });
+
+  // ============================================
+  // createWebhook
+  // ============================================
+
+  describe("createWebhook", () => {
+    it("should create a webhook and return the result with secret", async () => {
+      const mockResponse = {
+        success: true,
+        data: { ...mockWebhook, secret: "whsec_abc123" },
+      };
+      MockedHttpClient.prototype.post = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.createWebhook(ORG_ID, {
+        name: WEBHOOK_NAME,
+        urls: ["https://example.com/hook"],
+        events: ["signature.document.completed"],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.name).toBe(WEBHOOK_NAME);
+      expect(result.data.secret).toBe("whsec_abc123");
+      expect(MockedHttpClient.prototype.post).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks`,
+        {
+          name: WEBHOOK_NAME,
+          urls: ["https://example.com/hook"],
+          events: ["signature.document.completed"],
+        }
+      );
+    });
+
+    it("should throw AuthenticationError on 401", async () => {
+      const authError = new Error("Unauthorized");
+      (authError as any).statusCode = 401;
+      MockedHttpClient.prototype.post = jest.fn().mockRejectedValue(authError);
+      setup();
+
+      await expect(
+        TurboPartner.createWebhook(ORG_ID, {
+          name: WEBHOOK_NAME,
+          urls: ["https://example.com/hook"],
+          events: ["signature.document.completed"],
+        })
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it("should throw ValidationError on 400", async () => {
+      const validationError = new Error("Validation failed");
+      (validationError as any).statusCode = 400;
+      MockedHttpClient.prototype.post = jest.fn().mockRejectedValue(validationError);
+      setup();
+
+      await expect(
+        TurboPartner.createWebhook(ORG_ID, {
+          name: "",
+          urls: [],
+          events: [],
+        })
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+  });
+
+  // ============================================
+  // listWebhooks
+  // ============================================
+
+  describe("listWebhooks", () => {
+    it("should list webhooks without params", async () => {
+      const mockResponse = {
+        success: true,
+        data: { results: [mockWebhook], totalRecords: 1, limit: 50, offset: 0 },
+      };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.listWebhooks(ORG_ID);
+
+      expect(result.success).toBe(true);
+      expect(result.data.results).toHaveLength(1);
+      expect(result.data.totalRecords).toBe(1);
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks`,
+        undefined
+      );
+    });
+
+    it("should pass pagination params as query string", async () => {
+      const mockResponse = {
+        success: true,
+        data: { results: [], totalRecords: 0, limit: 10, offset: 20 },
+      };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      await TurboPartner.listWebhooks(ORG_ID, { limit: 10, offset: 20 });
+
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks`,
+        { limit: "10", offset: "20" }
+      );
+    });
+
+    it("should serialize boolean isActive as string", async () => {
+      const mockResponse = {
+        success: true,
+        data: { results: [], totalRecords: 0, limit: 50, offset: 0 },
+      };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      await TurboPartner.listWebhooks(ORG_ID, { isActive: true });
+
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks`,
+        { isActive: "true" }
+      );
+    });
+  });
+
+  // ============================================
+  // getWebhook
+  // ============================================
+
+  describe("getWebhook", () => {
+    it("should get a webhook by name", async () => {
+      const mockResponse = { success: true, data: mockWebhook };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.getWebhook(ORG_ID, WEBHOOK_NAME);
+
+      expect(result.success).toBe(true);
+      expect(result.data.name).toBe(WEBHOOK_NAME);
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}`
+      );
+    });
+
+    it("should throw NotFoundError on 404", async () => {
+      const notFoundError = new Error("Not found");
+      (notFoundError as any).statusCode = 404;
+      MockedHttpClient.prototype.get = jest.fn().mockRejectedValue(notFoundError);
+      setup();
+
+      await expect(
+        TurboPartner.getWebhook(ORG_ID, "nonexistent")
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+
+  // ============================================
+  // updateWebhook
+  // ============================================
+
+  describe("updateWebhook", () => {
+    it("should update a webhook with partial fields", async () => {
+      const mockResponse = {
+        success: true,
+        data: { ...mockWebhook, isActive: false },
+      };
+      MockedHttpClient.prototype.patch = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.updateWebhook(ORG_ID, WEBHOOK_NAME, {
+        isActive: false,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data.isActive).toBe(false);
+      expect(MockedHttpClient.prototype.patch).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}`,
+        { isActive: false }
+      );
+    });
+
+    it("should update urls and events", async () => {
+      const updated = {
+        ...mockWebhook,
+        urls: ["https://new.example.com/hook"],
+        events: ["signature.document.voided"],
+      };
+      const mockResponse = { success: true, data: updated };
+      MockedHttpClient.prototype.patch = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.updateWebhook(ORG_ID, WEBHOOK_NAME, {
+        urls: ["https://new.example.com/hook"],
+        events: ["signature.document.voided"],
+      });
+
+      expect(result.data.urls).toContain("https://new.example.com/hook");
+      expect(result.data.events).toContain("signature.document.voided");
+    });
+  });
+
+  // ============================================
+  // deleteWebhook
+  // ============================================
+
+  describe("deleteWebhook", () => {
+    it("should delete a webhook and return success", async () => {
+      const mockResponse = { success: true, message: "Webhook deleted" };
+      MockedHttpClient.prototype.delete = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.deleteWebhook(ORG_ID, WEBHOOK_NAME);
+
+      expect(result.success).toBe(true);
+      expect(MockedHttpClient.prototype.delete).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}`
+      );
+    });
+  });
+
+  // ============================================
+  // testWebhook
+  // ============================================
+
+  describe("testWebhook", () => {
+    it("should send a test event and return the delivery summary", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          deliveries: [],
+          summary: { total: 1, successful: 1, failed: 0, errors: [] },
+        },
+      };
+      MockedHttpClient.prototype.post = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.testWebhook(ORG_ID, WEBHOOK_NAME);
+
+      expect(result.success).toBe(true);
+      expect(result.data.summary.successful).toBe(1);
+      expect(MockedHttpClient.prototype.post).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}/test`,
+        {}
+      );
+    });
+
+    it("should pass event and data overrides", async () => {
+      const mockResponse = {
+        success: true,
+        data: {
+          deliveries: [],
+          summary: { total: 1, successful: 1, failed: 0, errors: [] },
+        },
+      };
+      MockedHttpClient.prototype.post = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      await TurboPartner.testWebhook(ORG_ID, WEBHOOK_NAME, {
+        event: "signature.document.voided",
+        data: { documentId: "doc-1" },
+      });
+
+      expect(MockedHttpClient.prototype.post).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}/test`,
+        { event: "signature.document.voided", data: { documentId: "doc-1" } }
+      );
+    });
+  });
+
+  // ============================================
+  // listWebhookDeliveries
+  // ============================================
+
+  describe("listWebhookDeliveries", () => {
+    it("should list deliveries for a webhook", async () => {
+      const mockDelivery = {
+        id: "delivery-1",
+        webhookId: "webhook-uuid-789",
+        event: "signature.document.completed",
+        statusCode: 200,
+        success: true,
+        attemptCount: 1,
+        createdOn: "2025-01-01T00:00:00.000Z",
+      };
+      const mockResponse = {
+        success: true,
+        data: { results: [mockDelivery], totalRecords: 1, limit: 50, offset: 0 },
+      };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      const result = await TurboPartner.listWebhookDeliveries(ORG_ID, WEBHOOK_NAME);
+
+      expect(result.success).toBe(true);
+      expect(result.data.results).toHaveLength(1);
+      expect(result.data.results[0].event).toBe("signature.document.completed");
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}/deliveries`,
+        undefined
+      );
+    });
+
+    it("should pass pagination params", async () => {
+      const mockResponse = {
+        success: true,
+        data: { results: [], totalRecords: 0, limit: 10, offset: 5 },
+      };
+      MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+      setup();
+
+      await TurboPartner.listWebhookDeliveries(ORG_ID, WEBHOOK_NAME, {
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        `/partner/${PARTNER_ID}/orgs/${ORG_ID}/webhooks/${WEBHOOK_NAME}/deliveries`,
+        { limit: "10", offset: "5" }
+      );
+    });
+  });
+});

--- a/packages/php-sdk/tests/Unit/TurboPartnerWebhooksTest.php
+++ b/packages/php-sdk/tests/Unit/TurboPartnerWebhooksTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use TurboDocx\Exceptions\ValidationException;
+use TurboDocx\Types\Requests\Partner\CreateWebhookRequest;
+use TurboDocx\Types\Requests\Partner\UpdateWebhookRequest;
+use TurboDocx\Types\Requests\Partner\ListWebhooksRequest;
+use TurboDocx\Types\Requests\Partner\TestWebhookRequest;
+use TurboDocx\Types\Requests\Partner\ListWebhookDeliveriesRequest;
+use TurboDocx\Types\Responses\Partner\WebhookResponse;
+use TurboDocx\Types\Responses\Partner\WebhookListResponse;
+use TurboDocx\Types\Responses\Partner\WebhookDeliveryListResponse;
+use TurboDocx\Types\Responses\Partner\TestWebhookResponse;
+use TurboDocx\Types\Responses\Partner\SuccessResponse;
+
+final class TurboPartnerWebhooksTest extends TestCase
+{
+    // =============================================
+    // CreateWebhookRequest Tests
+    // =============================================
+
+    public function testCreateWebhookRequestToArray(): void
+    {
+        $request = new CreateWebhookRequest(
+            name: 'my-signing-webhook',
+            urls: ['https://example.com/hook'],
+            events: ['signature.document.completed']
+        );
+
+        $array = $request->toArray();
+
+        $this->assertEquals('my-signing-webhook', $array['name']);
+        $this->assertEquals(['https://example.com/hook'], $array['urls']);
+        $this->assertEquals(['signature.document.completed'], $array['events']);
+    }
+
+    public function testCreateWebhookRequestWithMetadata(): void
+    {
+        $request = new CreateWebhookRequest(
+            name: 'my-webhook',
+            urls: ['https://example.com/hook'],
+            events: ['signature.document.completed'],
+            metadata: ['env' => 'production']
+        );
+
+        $array = $request->toArray();
+        $this->assertEquals(['env' => 'production'], $array['metadata']);
+    }
+
+    public function testCreateWebhookRequestEmptyNameThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        new CreateWebhookRequest(name: '', urls: ['https://example.com'], events: ['signature.document.completed']);
+    }
+
+    public function testCreateWebhookRequestEmptyUrlsThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        new CreateWebhookRequest(name: 'my-webhook', urls: [], events: ['signature.document.completed']);
+    }
+
+    public function testCreateWebhookRequestNonHttpsUrlThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        new CreateWebhookRequest(name: 'my-webhook', urls: ['http://insecure.example.com'], events: ['signature.document.completed']);
+    }
+
+    public function testCreateWebhookRequestEmptyEventsThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        new CreateWebhookRequest(name: 'my-webhook', urls: ['https://example.com'], events: []);
+    }
+
+    // =============================================
+    // UpdateWebhookRequest Tests
+    // =============================================
+
+    public function testUpdateWebhookRequestPartialFields(): void
+    {
+        $request = new UpdateWebhookRequest(isActive: false);
+        $array = $request->toArray();
+
+        $this->assertFalse($array['isActive']);
+        $this->assertArrayNotHasKey('urls', $array);
+        $this->assertArrayNotHasKey('events', $array);
+    }
+
+    public function testUpdateWebhookRequestAllFields(): void
+    {
+        $request = new UpdateWebhookRequest(
+            urls: ['https://new.example.com/hook'],
+            events: ['signature.document.voided'],
+            isActive: true
+        );
+
+        $array = $request->toArray();
+        $this->assertEquals(['https://new.example.com/hook'], $array['urls']);
+        $this->assertEquals(['signature.document.voided'], $array['events']);
+        $this->assertTrue($array['isActive']);
+    }
+
+    // =============================================
+    // ListWebhooksRequest Tests
+    // =============================================
+
+    public function testListWebhooksRequestToQueryString(): void
+    {
+        $request = new ListWebhooksRequest(limit: 10, offset: 20, isActive: true);
+        $params = $request->toQueryParams();
+
+        $this->assertEquals(10, $params['limit']);
+        $this->assertEquals(20, $params['offset']);
+        $this->assertTrue($params['isActive']);
+    }
+
+    public function testListWebhooksRequestEmptyWhenNoParams(): void
+    {
+        $request = new ListWebhooksRequest();
+        $this->assertEmpty($request->toQueryParams());
+    }
+
+    // =============================================
+    // TestWebhookRequest Tests
+    // =============================================
+
+    public function testTestWebhookRequestEmpty(): void
+    {
+        $request = new TestWebhookRequest();
+        $this->assertEmpty($request->toArray());
+    }
+
+    public function testTestWebhookRequestWithEvent(): void
+    {
+        $request = new TestWebhookRequest(event: 'signature.document.voided');
+        $array = $request->toArray();
+        $this->assertEquals('signature.document.voided', $array['event']);
+    }
+
+    public function testTestWebhookRequestWithData(): void
+    {
+        $request = new TestWebhookRequest(data: ['documentId' => 'doc-1']);
+        $array = $request->toArray();
+        $this->assertEquals(['documentId' => 'doc-1'], $array['data']);
+    }
+
+    // =============================================
+    // ListWebhookDeliveriesRequest Tests
+    // =============================================
+
+    public function testListWebhookDeliveriesRequestToQueryParams(): void
+    {
+        $request = new ListWebhookDeliveriesRequest(limit: 5, offset: 10);
+        $params = $request->toQueryParams();
+
+        $this->assertEquals(5, $params['limit']);
+        $this->assertEquals(10, $params['offset']);
+    }
+
+    // =============================================
+    // WebhookResponse Tests
+    // =============================================
+
+    public function testWebhookResponseFromArray(): void
+    {
+        $data = [
+            'success' => true,
+            'data' => [
+                'id' => 'webhook-uuid-789',
+                'name' => 'my-signing-webhook',
+                'urls' => ['https://example.com/hook'],
+                'events' => ['signature.document.completed'],
+                'isActive' => true,
+                'secret' => 'whsec_abc123',
+                'createdOn' => '2025-01-01T00:00:00.000Z',
+                'updatedOn' => '2025-01-01T00:00:00.000Z',
+            ],
+        ];
+
+        $response = WebhookResponse::fromArray($data);
+
+        $this->assertTrue($response->success);
+        $this->assertEquals('webhook-uuid-789', $response->data->id);
+        $this->assertEquals('my-signing-webhook', $response->data->name);
+        $this->assertEquals('whsec_abc123', $response->data->secret);
+        $this->assertTrue($response->data->isActive);
+    }
+
+    // =============================================
+    // WebhookListResponse Tests
+    // =============================================
+
+    public function testWebhookListResponseFromArray(): void
+    {
+        $data = [
+            'success' => true,
+            'data' => [
+                'results' => [
+                    ['id' => 'wh-1', 'name' => 'webhook-one', 'urls' => [], 'events' => [], 'isActive' => true],
+                    ['id' => 'wh-2', 'name' => 'webhook-two', 'urls' => [], 'events' => [], 'isActive' => false],
+                ],
+                'totalRecords' => 2,
+                'limit' => 50,
+                'offset' => 0,
+            ],
+        ];
+
+        $response = WebhookListResponse::fromArray($data);
+
+        $this->assertTrue($response->success);
+        $this->assertCount(2, $response->data->results);
+        $this->assertEquals(2, $response->data->totalRecords);
+        $this->assertEquals('webhook-one', $response->data->results[0]->name);
+    }
+
+    // =============================================
+    // WebhookDeliveryListResponse Tests
+    // =============================================
+
+    public function testWebhookDeliveryListResponseFromArray(): void
+    {
+        $data = [
+            'success' => true,
+            'data' => [
+                'results' => [
+                    [
+                        'id' => 'del-1',
+                        'webhookId' => 'webhook-uuid-789',
+                        'event' => 'signature.document.completed',
+                        'statusCode' => 200,
+                        'success' => true,
+                        'attemptCount' => 1,
+                        'createdOn' => '2025-01-01T00:00:00.000Z',
+                    ],
+                ],
+                'totalRecords' => 1,
+                'limit' => 50,
+                'offset' => 0,
+            ],
+        ];
+
+        $response = WebhookDeliveryListResponse::fromArray($data);
+
+        $this->assertTrue($response->success);
+        $this->assertCount(1, $response->data->results);
+        $this->assertEquals('signature.document.completed', $response->data->results[0]->event);
+    }
+
+    // =============================================
+    // TestWebhookResponse Tests
+    // =============================================
+
+    public function testTestWebhookResponseFromArray(): void
+    {
+        $data = [
+            'success' => true,
+            'data' => [
+                'deliveries' => [],
+                'summary' => [
+                    'total' => 1,
+                    'successful' => 1,
+                    'failed' => 0,
+                    'errors' => [],
+                ],
+            ],
+        ];
+
+        $response = TestWebhookResponse::fromArray($data);
+
+        $this->assertTrue($response->success);
+        $this->assertEquals(1, $response->data->summary->total);
+        $this->assertEquals(1, $response->data->summary->successful);
+        $this->assertEquals(0, $response->data->summary->failed);
+    }
+}

--- a/packages/py-sdk/tests/test_partner_webhooks.py
+++ b/packages/py-sdk/tests/test_partner_webhooks.py
@@ -1,0 +1,351 @@
+"""
+TurboPartner Webhook Management Tests
+
+Tests for webhook provisioning operations:
+- create_webhook
+- list_webhooks
+- get_webhook
+- update_webhook
+- delete_webhook
+- test_webhook
+- list_webhook_deliveries
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from turbodocx_sdk import TurboPartner
+
+
+PARTNER_ID = "test-partner-id"
+ORG_ID = "org-uuid-456"
+WEBHOOK_NAME = "my-signing-webhook"
+
+MOCK_WEBHOOK = {
+    "id": "webhook-uuid-789",
+    "name": WEBHOOK_NAME,
+    "urls": ["https://example.com/hook"],
+    "events": ["signature.document.completed"],
+    "isActive": True,
+    "createdOn": "2025-01-01T00:00:00.000Z",
+    "updatedOn": "2025-01-01T00:00:00.000Z",
+}
+
+
+class TestCreateWebhook:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_create_webhook(self):
+        mock_response = {"success": True, "data": {**MOCK_WEBHOOK, "secret": "whsec_abc"}}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.create_webhook(
+                org_id=ORG_ID,
+                name=WEBHOOK_NAME,
+                urls=["https://example.com/hook"],
+                events=["signature.document.completed"],
+            )
+
+        assert result["success"] is True
+        assert result["data"]["name"] == WEBHOOK_NAME
+        assert result["data"]["secret"] == "whsec_abc"
+        mock_client.post.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks",
+            data={
+                "name": WEBHOOK_NAME,
+                "urls": ["https://example.com/hook"],
+                "events": ["signature.document.completed"],
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_webhook_with_metadata(self):
+        mock_response = {"success": True, "data": MOCK_WEBHOOK}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.create_webhook(
+                org_id=ORG_ID,
+                name=WEBHOOK_NAME,
+                urls=["https://example.com/hook"],
+                events=["signature.document.completed"],
+                metadata={"env": "production"},
+            )
+
+        call_data = mock_client.post.call_args[1]["data"]
+        assert call_data["metadata"] == {"env": "production"}
+
+
+class TestListWebhooks:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_list_webhooks_no_params(self):
+        mock_response = {
+            "success": True,
+            "data": {"results": [MOCK_WEBHOOK], "totalRecords": 1, "limit": 50, "offset": 0},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.list_webhooks(org_id=ORG_ID)
+
+        assert result["success"] is True
+        assert len(result["data"]["results"]) == 1
+        mock_client.get.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_webhooks_with_pagination(self):
+        mock_response = {
+            "success": True,
+            "data": {"results": [], "totalRecords": 0, "limit": 10, "offset": 20},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.list_webhooks(org_id=ORG_ID, limit=10, offset=20)
+
+        mock_client.get.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks?limit=10&offset=20"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_webhooks_filter_by_active(self):
+        mock_response = {
+            "success": True,
+            "data": {"results": [], "totalRecords": 0, "limit": 50, "offset": 0},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.list_webhooks(org_id=ORG_ID, is_active=True)
+
+        url = mock_client.get.call_args[0][0]
+        assert "is_active=true" in url
+
+
+class TestGetWebhook:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_get_webhook(self):
+        mock_response = {"success": True, "data": MOCK_WEBHOOK}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.get_webhook(org_id=ORG_ID, webhook_name=WEBHOOK_NAME)
+
+        assert result["success"] is True
+        assert result["data"]["name"] == WEBHOOK_NAME
+        mock_client.get.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks/{WEBHOOK_NAME}"
+        )
+
+
+class TestUpdateWebhook:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_update_webhook_is_active(self):
+        mock_response = {"success": True, "data": {**MOCK_WEBHOOK, "isActive": False}}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.update_webhook(
+                org_id=ORG_ID, webhook_name=WEBHOOK_NAME, is_active=False
+            )
+
+        assert result["data"]["isActive"] is False
+        mock_client.patch.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks/{WEBHOOK_NAME}",
+            data={"isActive": False},
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_webhook_urls_and_events(self):
+        updated = {**MOCK_WEBHOOK, "urls": ["https://new.example.com/hook"]}
+        mock_response = {"success": True, "data": updated}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.update_webhook(
+                org_id=ORG_ID,
+                webhook_name=WEBHOOK_NAME,
+                urls=["https://new.example.com/hook"],
+            )
+
+        call_data = mock_client.patch.call_args[1]["data"]
+        assert call_data["urls"] == ["https://new.example.com/hook"]
+
+
+class TestDeleteWebhook:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_delete_webhook(self):
+        mock_response = {"success": True, "message": "Webhook deleted"}
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.delete = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.delete_webhook(
+                org_id=ORG_ID, webhook_name=WEBHOOK_NAME
+            )
+
+        assert result["success"] is True
+        mock_client.delete.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks/{WEBHOOK_NAME}"
+        )
+
+
+class TestTestWebhook:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_test_webhook_default(self):
+        mock_response = {
+            "success": True,
+            "data": {"deliveries": [], "summary": {"total": 1, "successful": 1, "failed": 0, "errors": []}},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.test_webhook(
+                org_id=ORG_ID, webhook_name=WEBHOOK_NAME
+            )
+
+        assert result["data"]["summary"]["successful"] == 1
+        mock_client.post.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks/{WEBHOOK_NAME}/test",
+            data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_test_webhook_with_event_override(self):
+        mock_response = {
+            "success": True,
+            "data": {"deliveries": [], "summary": {"total": 1, "successful": 1, "failed": 0, "errors": []}},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.post = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.test_webhook(
+                org_id=ORG_ID,
+                webhook_name=WEBHOOK_NAME,
+                event="signature.document.voided",
+                data={"doc": "123"},
+            )
+
+        call_data = mock_client.post.call_args[1]["data"]
+        assert call_data["event"] == "signature.document.voided"
+        assert call_data["data"] == {"doc": "123"}
+
+
+class TestListWebhookDeliveries:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+        TurboPartner.configure(partner_api_key="TDXP-test-key", partner_id=PARTNER_ID)
+
+    @pytest.mark.asyncio
+    async def test_list_webhook_deliveries(self):
+        mock_delivery = {
+            "id": "del-1",
+            "webhookId": "webhook-uuid-789",
+            "event": "signature.document.completed",
+            "statusCode": 200,
+            "success": True,
+            "attemptCount": 1,
+            "createdOn": "2025-01-01T00:00:00.000Z",
+        }
+        mock_response = {
+            "success": True,
+            "data": {"results": [mock_delivery], "totalRecords": 1, "limit": 50, "offset": 0},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            result = await TurboPartner.list_webhook_deliveries(
+                org_id=ORG_ID, webhook_name=WEBHOOK_NAME
+            )
+
+        assert len(result["data"]["results"]) == 1
+        mock_client.get.assert_called_once_with(
+            f"/partner/{PARTNER_ID}/orgs/{ORG_ID}/webhooks/{WEBHOOK_NAME}/deliveries"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_webhook_deliveries_with_pagination(self):
+        mock_response = {
+            "success": True,
+            "data": {"results": [], "totalRecords": 0, "limit": 10, "offset": 5},
+        }
+
+        with patch.object(TurboPartner, "_get_client") as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+
+            await TurboPartner.list_webhook_deliveries(
+                org_id=ORG_ID, webhook_name=WEBHOOK_NAME, limit=10, offset=5
+            )
+
+        url = mock_client.get.call_args[0][0]
+        assert "limit=10" in url
+        assert "offset=5" in url


### PR DESCRIPTION
## Related
**Issue:** nicolasiscoding/RapidDocxBackend#1272
**Backend PR:** nicolasiscoding/RapidDocxBackend#1312
**SDK PR:** TurboDocx/SDK#TBD (this PR)

## Description

Test scaffolding for the partner webhook provisioning SDK methods landing under issue [nicolasiscoding/RapidDocxBackend#1272](https://github.com/nicolasiscoding/RapidDocxBackend/issues/1272). The corresponding backend changes are in [nicolasiscoding/RapidDocxBackend#1312](https://github.com/nicolasiscoding/RapidDocxBackend/pull/1312).

### What's in this PR
- `packages/js-sdk/tests/partner-webhooks.test.ts`
- `packages/py-sdk/tests/test_partner_webhooks.py`
- `packages/go-sdk/turbopartner_webhooks_test.go`
- `packages/php-sdk/tests/Unit/TurboPartnerWebhooksTest.php`
- `packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerWebhooksTest.java`

These cover the 7 partner webhook methods that will be added to each SDK:
`createWebhook`, `listWebhooks`, `getWebhook`, `updateWebhook`, `deleteWebhook`, `testWebhook`, `listWebhookDeliveries`.

### What's NOT in this PR yet (follow-up)
- Source implementations in each SDK's `TurboPartner` (or equivalent) module
- New types: `Webhook`, `WebhookDelivery`, `WebhookEvent`, request / response shapes
- New partner scopes: `webhooks:create | read | update | delete`

**Tests will fail until the source methods are added** — this is intentional, the PR is open as a draft so the test surface can be reviewed independently of the implementations.

## Pre-Review Checklist
- [x] Test files added across all 5 SDKs
- [ ] Source methods implemented per SDK
- [ ] New scopes added to JS `PartnerScope` union
- [ ] Cross-SDK parity table updated (`.claude/rules/cross-sdk-parity.md`)
- [ ] All test suites green

## Deployment Notes
None — tests only, no source changes that would ship.