### PR TITLE
chore(release): bump all SDKs to 0.3.0

### DIFF
--- a/packages/java-sdk/pom.xml
+++ b/packages/java-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.turbodocx</groupId>
     <artifactId>turbodocx-sdk</artifactId>
-    <version>0.2.0</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>TurboDocx SDK</name>

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbodocx/sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TurboDocx JavaScript SDK - Digital signatures, document generation, and AI-powered workflows",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/php-sdk/composer.json
+++ b/packages/php-sdk/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "turbodocx/sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Official PHP SDK for TurboDocx - E-signature API, document generation, PDF signing, and workflow automation",
   "type": "library",
   "license": "MIT",

--- a/packages/py-sdk/pyproject.toml
+++ b/packages/py-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "turbodocx-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "TurboDocx Python SDK - Digital signatures, document generation, and AI-powered workflows"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps js, py, php, java manifests to 0.3.0. Go is tag-only.

Once merged, cuts 5 GitHub releases (`js-sdk-v0.3.0`, `py-sdk-v0.3.0`, `php-sdk-v0.3.0`, `java-sdk-v0.3.0`, `go-sdk-v0.3.0`) → triggers per-SDK publish workflows to npm, PyPI, Packagist, Maven Central, and the Go module proxy.

Minor bump for the new TurboWebhooks module (PR #30).