### PR TITLE
fix(ci): guard publish-java to java-sdk-v* releases only

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -13,6 +13,13 @@ on:
 jobs:
   publish:
     name: Publish to Maven Central
+    # Only publish on a java-sdk-v* release (or a manual dispatch). Without this
+    # guard the job runs on EVERY release event, so cutting js/py/go/php/ruby
+    # releases together fires concurrent Maven deployments of the same
+    # com.turbodocx:turbodocx-sdk coordinate, which collide ("currently being
+    # published in another deployment"). The other publish workflows already
+    # filter this way.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'java-sdk-v')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Problem
`publish-java.yml` had no tag filter on its `publish` job, so it ran on **every** release event. Cutting the 0.4.0 releases (js/py/go/php/java) together fired 5 concurrent Maven deployments of the same `com.turbodocx:turbodocx-sdk:0.4.0` coordinate, which collided:
> Component with coordinate 'com.turbodocx:turbodocx-sdk:0.4.0' is currently being published in another deployment

## Fix
Add the same guard the other publish workflows already use, filtering release events to `java-sdk-v*` (and letting `workflow_dispatch` through):
```yaml
if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'java-sdk-v')
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)