### PR TITLE
chore(security): add Dependabot security-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,114 @@
+version: 2
+
+updates:
+  # NPM dependencies (root) - security updates only
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # NPM dependencies (js-sdk) - security updates only
+  - package-ecosystem: "npm"
+    directory: "/packages/js-sdk"
+    schedule:
+      interval: "daily"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Go dependencies (go-sdk) - security updates only
+  - package-ecosystem: "gomod"
+    directory: "/packages/go-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Maven dependencies (java-sdk) - security updates only
+  - package-ecosystem: "maven"
+    directory: "/packages/java-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Composer dependencies (php-sdk) - security updates only
+  - package-ecosystem: "composer"
+    directory: "/packages/php-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Pip dependencies (py-sdk) - security updates only
+  - package-ecosystem: "pip"
+    directory: "/packages/py-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # Bundler dependencies (ruby-sdk) - security updates only
+  - package-ecosystem: "bundler"
+    directory: "/packages/ruby-sdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"
+
+  # GitHub Actions dependencies - security updates only
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    commit-message:
+      prefix: "security"
+      include: "scope"
+    open-pull-requests-limit: 0
+    allow:
+      - dependency-type: "all"
+    rebase-strategy: "auto"


### PR DESCRIPTION
Closes #42

## Summary
- Adds `.github/dependabot.yml` covering every ecosystem/directory in this monorepo: root npm, `packages/js-sdk` (npm), `packages/go-sdk` (gomod), `packages/java-sdk` (maven), `packages/php-sdk` (composer), `packages/py-sdk` (pip), `packages/ruby-sdk` (bundler), and GitHub Actions workflows.
- Modeled directly on the working `TurboDocx/html-to-docx` Dependabot config (same commit-message prefix/scope, rebase strategy, and `open-pull-requests-limit: 0`).
- `open-pull-requests-limit: 0` means Dependabot will only ever open PRs for security vulnerability fixes it detects — there's no version-bump noise from routine dependency updates.
- npm ecosystems check daily; everything else (gomod, maven, composer, pip, bundler, github-actions) checks weekly.
- Part of the patch-duty tooling audit to get security alerting/PRs enabled consistently across TurboDocx repos.

## Test plan
- [ ] Confirm Dependabot picks up the config in repo Insights > Dependency graph > Dependabot
- [ ] Confirm no noisy non-security PRs get opened
- [ ] Watch for a real security PR on the next vulnerable dependency to validate end-to-end
