### PR TITLE
fix(deps): bump handlebars to 4.7.9 (GHSA-2w6w-674q-4c4q, critical RCE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1854,9 +1854,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1853,9 +1853,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Bumps **handlebars `4.7.8` → `4.7.9`** in both lockfiles to resolve the **critical** Dependabot alert **GHSA-2w6w-674q-4c4q / CVE-2026-33937**.

## The vulnerability

`Handlebars.compile()` accepts a pre-parsed AST as well as a template string. The code generator emits a `NumberLiteral` node's `value` field **verbatim** into the generated (eval'd) JavaScript, without quoting or sanitization — a type-confusion bug. An attacker who can pass a crafted AST to `compile()` can inject and execute arbitrary JavaScript, leading to **RCE**. Patched in 4.7.9.

## Impact on this repo: not runtime-reachable

- handlebars is **not** a direct dependency and appears in **no** `package.json`.
- It is pulled in **transitively and dev-only** via `ts-jest → handlebars` (`^4.7.8`), used solely by the Jest test toolchain.
- The published `@turbodocx/sdk` ships `dist/` only and has **zero runtime dependencies** (per `.claude/rules/js-sdk.md`), so handlebars is never installed for consumers.
- Nothing in the codebase calls `Handlebars.compile()` — `grep` for `handlebars` in `*.ts/*.js` returns nothing.

So the practical risk is nil; this bump clears the critical alert and keeps the security dashboard clean.

## Why it's safe / minimal

- Patch release: `ts-jest`'s `^4.7.8` range already permits `4.7.9`, so **no manifest change** is required.
- Diff is **6 lines total** — 3 per lockfile (`version` / `resolved` / `integrity`). handlebars' own sub-dependencies are unchanged.

## Verification

- `npm ci` — passes (registry integrity hash for 4.7.9 verified).
- `npm run build:js` — passes (tsc).
- `npm run test:js` — **271/271 tests pass**.
- `npm audit --audit-level=critical` — exit 0 (this critical is resolved).

## Notes

This is a dependency bump (a **standard change** per `CLAUDE.md`), so no Change-Request issue is filed. It's a focused, surgical alternative to the bundled Dependabot group PRs (#43/#44), which also rewrite ~2,500 unrelated lockfile lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)