### PR TITLE
fix(deps): patch 6 high-severity alerts (brace-expansion, js-yaml, minimatch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,9 +1239,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2725,9 +2725,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2906,9 +2906,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3846,7 +3846,7 @@
     },
     "packages/js-sdk": {
       "name": "@turbodocx/sdk",
-      "version": "0.1.4",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbodocx/sdk",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbodocx/sdk",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1238,9 +1238,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2724,9 +2724,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2905,9 +2905,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## What

Resolves **all 6 open high-severity Dependabot alerts** in this repo — lockfiles only, no manifest change.

| Package | Alerts | Was | Now | Advisory |
|---|---|---|---|---|
| brace-expansion | #17, #35 | 1.1.12 | **1.1.16** | GHSA-3jxr-9vmj-r5cp |
| js-yaml | #18, #36 | 3.14.2 | **3.15.0** | GHSA-52cp-r559-cp3m |
| minimatch | #3, #21 | 3.1.2 | **3.1.5** | GHSA-7r86-cg39-jmmj |

Each advisory is filed **twice** — once per lockfile (root and `packages/js-sdk`) — so both lockfiles are updated. 3 packages × 2 lockfiles = 6 alerts.

## Why it's low-risk

- All three are **dev-only transitive** dependencies of the Jest/ts-jest test toolchain. None is a direct dependency; none appears in any `package.json`.
- The JS SDK has **zero runtime dependencies**, so none of this ships to consumers of `@turbodocx/sdk` (`dist/` only).
- **No `overrides` pin was used.** Every patched version already satisfies the semver range its consumers declare (`minimatch ^3.1.1`, `brace-expansion ^1.1.x`, `js-yaml ^3.13.x`), so a plain `npm update` resolves them. That keeps the diff to 21 lines per lockfile and lets future patch releases flow normally instead of freezing the version.

## Verification

- `npm ci` — ✅
- `npm run build:js` (tsc) — ✅
- `npm run test:js` — ✅ **271 / 271 passing**

_Standard change (dependency/security bump) — no Change Request issue per `CLAUDE.md`._

🤖 Generated with [Claude Code](https://claude.com/claude-code)