### PR TITLE
chore: release v0.6.1 across all SDKs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4722,7 +4722,7 @@
     },
     "packages/js-sdk": {
       "name": "@turbodocx/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/packages/go-sdk/turbodocx.go
+++ b/packages/go-sdk/turbodocx.go
@@ -27,7 +27,7 @@ import (
 )
 
 // Version is the current SDK version
-const Version = "0.6.0"
+const Version = "0.6.1"
 
 // Client is the main TurboDocx API client
 type Client struct {

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -87,7 +87,7 @@ A modern, developer-first alternative to legacy e-signature platforms:
 <dependency>
     <groupId>com.turbodocx</groupId>
     <artifactId>turbodocx-sdk</artifactId>
-    <version>0.2.0</version>
+    <version>0.6.1</version>
 </dependency>
 ```
 

--- a/packages/java-sdk/pom.xml
+++ b/packages/java-sdk/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.turbodocx</groupId>
     <artifactId>turbodocx-sdk</artifactId>
-    <version>0.6.0</version>
+    <version>0.6.1</version>
     <packaging>jar</packaging>
 
     <name>TurboDocx SDK</name>

--- a/packages/java-sdk/src/main/java/com/turbodocx/ClientContext.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/ClientContext.java
@@ -122,7 +122,7 @@ public final class ClientContext {
     // User-Agent because the JAR manifest's Implementation-Version is only present
     // in a packaged jar built with the manifest entry — it is null when running
     // from classes/ (tests) or a jar built without it, which silently reported 0.0.0.
-    static final String VERSION = "0.6.0";
+    static final String VERSION = "0.6.1";
 
     private static String getSdkVersion() {
         try {

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@turbodocx/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@turbodocx/sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turbodocx/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TurboDocx JavaScript SDK - Digital signatures, document generation, and AI-powered workflows",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/php-sdk/composer.json
+++ b/packages/php-sdk/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "turbodocx/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Official PHP SDK for TurboDocx - E-signature API, document generation, PDF signing, and workflow automation",
   "type": "library",
   "license": "MIT",

--- a/packages/php-sdk/composer.lock
+++ b/packages/php-sdk/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a632b99c29cb63b1172cf116244b2954",
+    "content-hash": "de15e025d0c7344fce540e58b55b8853",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/packages/py-sdk/pyproject.toml
+++ b/packages/py-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "turbodocx-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "TurboDocx Python SDK - Digital signatures, document generation, and AI-powered workflows"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/py-sdk/src/turbodocx_sdk/__init__.py
+++ b/packages/py-sdk/src/turbodocx_sdk/__init__.py
@@ -5,7 +5,7 @@ Official SDK for TurboDocx API - Digital signatures, document generation,
 and AI-powered workflows.
 """
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from typing import Optional
 

--- a/packages/ruby-sdk/Gemfile.lock
+++ b/packages/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbodocx-sdk (0.6.0)
+    turbodocx-sdk (0.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby-sdk/lib/turbodocx_sdk.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk.rb
@@ -11,5 +11,5 @@ require_relative "turbodocx_sdk/deliverable"
 require_relative "turbodocx_sdk/turbo_webhooks"
 
 module TurboDocxSdk
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/packages/ruby-sdk/turbodocx-sdk.gemspec
+++ b/packages/ruby-sdk/turbodocx-sdk.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "turbodocx-sdk"
-  spec.version       = "0.6.0"
+  spec.version       = "0.6.1"
   spec.authors       = ["TurboDocx"]
   spec.email         = ["team@turbodocx.com"]
 


### PR DESCRIPTION
Lockstep patch bump for the dependency security sweep in #54 / CR #55.

**Patch, not minor** — no API surface changed. The only source edits in #54 were internal: `moduleResolution` → node16, and a `toBlobPart()` helper forced by `@types/node` 26 making `Buffer` an invalid `BlobPart`.

All nine version sites → 0.6.1:

| SDK | Sites |
|---|---|
| js-sdk | `package.json` + both `package-lock.json` embeds |
| py-sdk | `pyproject.toml` + `__init__.py` |
| go-sdk | `turbodocx.go` `const Version` |
| php-sdk | `composer.json` |
| java-sdk | `pom.xml` + `ClientContext.java` `VERSION` |
| ruby-sdk | `.gemspec` + `lib/turbodocx_sdk.rb` + `Gemfile.lock` |

### One trap worth noting

`pom.xml` line 153 is `central-publishing-maven-plugin`, which is **coincidentally also 0.6.0**. A blind find-and-replace across the pom would have silently downgraded the release plugin. The bump targets the project version line only; line 153 is intentionally left alone.

### Drive-by fix

`packages/java-sdk/README.md` still showed `<version>0.2.0</version>`. Java has no version-less install form, so users copy that literal — it had drifted four minor versions behind.

### Verification

Tests, all six green: **js 306 · php 341 · py 319 · java 305 · ruby 303 · go ok**. `npm ci --dry-run` clean, which is what validates lock/package.json version agreement.