### PR TITLE
feat: TurboSign reminders + document expiration across all six SDKs

### DIFF
--- a/.claude/rules/cross-sdk-parity.md
+++ b/.claude/rules/cross-sdk-parity.md
@@ -14,6 +14,25 @@ All SDKs must implement the same operations. When adding a feature to one SDK, i
 | void | `void()` | `void_document()` | `VoidDocument()` | `void()` | `voidDocument()` | `void_document()` |
 | resend | `resend()` | `resend_email()` | `ResendEmail()` | `resend()` | `resendEmail()` | `resend_email()` |
 | getAuditTrail | `getAuditTrail()` | `get_audit_trail()` | `GetAuditTrail()` | `getAuditTrail()` | `getAuditTrail()` | `get_audit_trail()` |
+| sendReminder | `sendReminder()` | `send_reminder()` | `SendReminder()` | `sendReminder()` | `sendReminder()` | `send_reminder()` |
+
+**sendReminder note:** a standalone nudge, deliberately decoupled from the automatic reminder
+schedule — it ignores the configured cadence, works when reminders are disabled or the per-signer
+cap is spent, and does not consume that cap. Only CURRENT-signing-order signers are emailed; a
+later-order or already-signed recipient comes back as a `skipped_*` result rather than being
+dropped. `recipientIds` is optional (omit to remind everyone eligible); when supplied the API is
+all-or-nothing. Every SDK omits the key entirely for an empty list — the API requires at least one
+id when the key is present, so sending `[]` would guarantee a 400.
+
+**Schedule overrides:** both send paths (`createSignatureReviewLink`, `sendSignature`) accept the
+eight per-document reminder/expiration fields. Two rules every SDK follows:
+1. **Durations are JSON-encoded on BOTH paths.** `multipart/form-data` cannot carry a nested
+   `{value, unit}`, and the API decodes a JSON-string duration on either content type — so one
+   code path serves multipart and JSON, exactly as `recipients`/`fields` are already handled.
+2. **Presence is null-checked, never truthiness.** `false` (feature off), `0` (no reminders /
+   never warn) and `-1` (unlimited) are all meaningful. Go uses pointer fields and Java boxed
+   types specifically so "unset" stays distinguishable from a deliberate zero value; a truthiness
+   check would drop them and silently fall back to the org default.
 
 **Configure note:** Go and Java do NOT expose a named `configure()` — Go configures via per-module
 constructors (`NewTurboSignClient`, `NewQuoteClient`, `NewWebhooksClient`, …) and Java via

--- a/packages/go-sdk/turbosign.go
+++ b/packages/go-sdk/turbosign.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 )
 
 // TurboSignClient provides digital signature operations
@@ -70,6 +71,48 @@ type Field struct {
 }
 
 // CreateSignatureReviewLinkRequest is the request for CreateSignatureReviewLink
+// Duration is a configured length of time.
+//
+// The unit is carried alongside the value rather than normalised away, so "48 hours" stays
+// "48 hours" instead of reading back as "2 days".
+type Duration struct {
+	// Value is a whole number of units. Minimum 1, except ExpirationWarning where 0 means
+	// "never warn".
+	Value int `json:"value"`
+	// Unit is "hours" or "days".
+	Unit string `json:"unit"`
+}
+
+// SignatureSchedule holds per-document reminder + expiration overrides.
+//
+// Every field is a POINTER because "unset" must stay distinguishable from a deliberate false or
+// 0: RemindersEnabled=false (feature off), MaxReminders=0 (no reminders) and MaxReminders=-1
+// (unlimited) are all meaningful, and Go's zero values would otherwise silently fall back to the
+// organization's default — the opposite of what the caller asked for.
+//
+// An omitted field inherits the org default; omitting the whole set means "use the org policy as
+// it stands at send time". Both features are off by default.
+type SignatureSchedule struct {
+	// RemindersEnabled turns reminder emails on for this document.
+	RemindersEnabled *bool
+	// ReminderDelay is how long after the invitation before the FIRST reminder.
+	ReminderDelay *Duration
+	// ReminderInterval is the gap between subsequent reminders.
+	ReminderInterval *Duration
+	// MaxReminders caps reminders per signer. -1 means unlimited, 0 means none. Never caps
+	// expiry warnings.
+	MaxReminders *int
+	// ExpirationEnabled closes the signing window after ExpireAfter.
+	ExpirationEnabled *bool
+	// ExpireAfter is how long the document stays signable, counted from sending.
+	ExpireAfter *Duration
+	// ExpirationWarning is how far BEFORE expiry warning emails start. A zero value means no
+	// warnings at all.
+	ExpirationWarning *Duration
+	// ExpirationWarningInterval is the gap between warnings once the window is open.
+	ExpirationWarningInterval *Duration
+}
+
 type CreateSignatureReviewLinkRequest struct {
 	// File content (use this OR FileLink/DeliverableID/TemplateID)
 	File     []byte
@@ -90,6 +133,9 @@ type CreateSignatureReviewLinkRequest struct {
 	SenderName          string
 	SenderEmail         string
 	CCEmails            []string
+
+	// Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+	SignatureSchedule
 }
 
 // ReviewRecipient represents a recipient in the review link response
@@ -131,6 +177,9 @@ type SendSignatureRequest struct {
 	SenderName          string
 	SenderEmail         string
 	CCEmails            []string
+
+	// Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+	SignatureSchedule
 }
 
 // SendSignatureResponse is the response from SendSignature
@@ -154,6 +203,26 @@ type RecipientResponse struct {
 // DocumentStatusResponse is the response from GetStatus
 type DocumentStatusResponse struct {
 	Status string `json:"status"`
+	// ExpiresAt is when the signing window closes, if the document has a deadline. Empty when
+	// expiration is off (the default), which means the document never expires.
+	ExpiresAt string `json:"expiresAt,omitempty"`
+}
+
+// ReminderResult is the outcome for one recipient of a reminder request.
+type ReminderResult struct {
+	RecipientID string `json:"recipientId"`
+	// Status is e.g. "sent", "skipped_wrong_order", "skipped_completed".
+	Status string `json:"status"`
+	// ReminderCount is the count after the send; only meaningful when Status is "sent".
+	ReminderCount int `json:"reminderCount,omitempty"`
+	// Phase is "reminder" or "expiring" — which email was sent.
+	Phase string `json:"phase,omitempty"`
+}
+
+// SendReminderResponse is the response from SendReminder.
+type SendReminderResponse struct {
+	// Results holds one entry per recipient considered, including those skipped and why.
+	Results []ReminderResult `json:"results"`
 }
 
 // VoidDocumentResponse is the response from VoidDocument
@@ -263,6 +332,11 @@ func (c *TurboSignClient) CreateSignatureReviewLink(ctx context.Context, req *Cr
 		formData["ccEmails"] = string(ccEmailsJSON)
 	}
 
+	// Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+	if err := applyScheduleOverrides(formData, req.SignatureSchedule); err != nil {
+		return nil, err
+	}
+
 	var response CreateSignatureReviewLinkResponse
 
 	if len(req.File) > 0 {
@@ -335,6 +409,11 @@ func (c *TurboSignClient) SendSignature(ctx context.Context, req *SendSignatureR
 			return nil, fmt.Errorf("marshal ccEmails: %w", err)
 		}
 		formData["ccEmails"] = string(ccEmailsJSON)
+	}
+
+	// Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+	if err := applyScheduleOverrides(formData, req.SignatureSchedule); err != nil {
+		return nil, err
 	}
 
 	var response SendSignatureResponse
@@ -427,6 +506,86 @@ func (c *TurboSignClient) ResendEmail(ctx context.Context, documentID string, re
 	var response ResendEmailResponse
 
 	err := c.http.Post(ctx, "/turbosign/documents/"+documentID+"/resend-email", map[string][]string{"recipientIds": recipientIDs}, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// applyScheduleOverrides copies per-document reminder/expiration overrides onto an outgoing
+// request body.
+//
+// Durations are JSON-encoded. multipart/form-data has no notion of a nested value, so a
+// {value, unit} object cannot survive the file-upload path as an object. The API decodes a
+// JSON-string duration on both content types, so encoding uniformly keeps one code path for the
+// multipart and JSON branches — the same treatment recipients and fields already get.
+//
+// Nil pointers are skipped, which is what preserves "unset" as distinct from a deliberate false
+// or 0.
+// Scalars are formatted as strings because formData is map[string]string on both the multipart
+// and JSON branches — the API's validation coerces them, exactly as it already does for the
+// JSON-encoded recipients, fields and ccEmails this SDK sends.
+func applyScheduleOverrides(formData map[string]string, schedule SignatureSchedule) error {
+	if schedule.RemindersEnabled != nil {
+		formData["remindersEnabled"] = strconv.FormatBool(*schedule.RemindersEnabled)
+	}
+	if schedule.MaxReminders != nil {
+		formData["maxReminders"] = strconv.Itoa(*schedule.MaxReminders)
+	}
+	if schedule.ExpirationEnabled != nil {
+		formData["expirationEnabled"] = strconv.FormatBool(*schedule.ExpirationEnabled)
+	}
+
+	durations := []struct {
+		key      string
+		duration *Duration
+	}{
+		{"reminderDelay", schedule.ReminderDelay},
+		{"reminderInterval", schedule.ReminderInterval},
+		{"expireAfter", schedule.ExpireAfter},
+		{"expirationWarning", schedule.ExpirationWarning},
+		{"expirationWarningInterval", schedule.ExpirationWarningInterval},
+	}
+	for _, d := range durations {
+		if d.duration == nil {
+			continue
+		}
+		encoded, err := json.Marshal(d.duration)
+		if err != nil {
+			return fmt.Errorf("marshal %s: %w", d.key, err)
+		}
+		formData[d.key] = string(encoded)
+	}
+
+	return nil
+}
+
+// SendReminder sends a reminder email to a document's outstanding signers.
+//
+// This is a standalone nudge, deliberately decoupled from the automatic reminder schedule: it
+// ignores the configured cadence, works even when reminders are disabled or the per-signer cap is
+// already spent, and does not consume that cap.
+//
+// Only signers at the CURRENT signing order are emailed. A recipient at a later order (or one who
+// has already signed) is reported back as skipped rather than silently dropped, so the caller can
+// tell that nobody was emailed.
+//
+// Pass nil (or an empty slice) for recipientIDs to remind every eligible signer. When ids are
+// supplied the request is all-or-nothing: if any is not a current-order pending signer the API
+// rejects the whole call and sends nothing.
+func (c *TurboSignClient) SendReminder(ctx context.Context, documentID string, recipientIDs []string) (*SendReminderResponse, error) {
+	var response SendReminderResponse
+
+	// Only include the filter when it actually names someone. The API requires at least one id
+	// when the key is present, so forwarding an empty slice would guarantee a 400 — an empty list
+	// is far more likely to mean "no filter" than "remind nobody".
+	body := map[string]interface{}{}
+	if len(recipientIDs) > 0 {
+		body["recipientIds"] = recipientIDs
+	}
+
+	err := c.http.Post(ctx, "/turbosign/documents/"+documentID+"/send-reminder", body, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-sdk/turbosign_schedule_test.go
+++ b/packages/go-sdk/turbosign_schedule_test.go
@@ -1,0 +1,179 @@
+package turbodocx
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TurboSign reminder + expiration schedule tests.
+//
+// Mirrors the js-sdk, py-sdk and ruby-sdk suites case-for-case, per the cross-SDK test-parity
+// rule.
+//
+// Durations are JSON-encoded on both send paths: multipart/form-data cannot carry a nested value,
+// and the API decodes a JSON-string duration on either content type, so one code path serves both.
+// Request-body keys stay camelCase — the API is not snake_case-aware.
+
+func boolPtr(b bool) *bool { return &b }
+func intPtr(i int) *int    { return &i }
+
+// captureFormData runs applyScheduleOverrides in isolation so the assertions describe the wire
+// shape without standing up a full multipart send.
+func captureFormData(t *testing.T, schedule SignatureSchedule) map[string]string {
+	t.Helper()
+	formData := map[string]string{}
+	if err := applyScheduleOverrides(formData, schedule); err != nil {
+		t.Fatalf("applyScheduleOverrides returned an error: %v", err)
+	}
+	return formData
+}
+
+func TestApplyScheduleOverrides_SendsEveryField(t *testing.T) {
+	formData := captureFormData(t, SignatureSchedule{
+		RemindersEnabled:          boolPtr(true),
+		ReminderDelay:             &Duration{Value: 3, Unit: "days"},
+		ReminderInterval:          &Duration{Value: 12, Unit: "hours"},
+		MaxReminders:              intPtr(5),
+		ExpirationEnabled:         boolPtr(true),
+		ExpireAfter:               &Duration{Value: 30, Unit: "days"},
+		ExpirationWarning:         &Duration{Value: 3, Unit: "days"},
+		ExpirationWarningInterval: &Duration{Value: 1, Unit: "days"},
+	})
+
+	if formData["remindersEnabled"] != "true" {
+		t.Errorf("remindersEnabled = %q, want \"true\"", formData["remindersEnabled"])
+	}
+	if formData["maxReminders"] != "5" {
+		t.Errorf("maxReminders = %q, want \"5\"", formData["maxReminders"])
+	}
+	if formData["expirationEnabled"] != "true" {
+		t.Errorf("expirationEnabled = %q, want \"true\"", formData["expirationEnabled"])
+	}
+
+	var decoded Duration
+	if err := json.Unmarshal([]byte(formData["reminderDelay"]), &decoded); err != nil {
+		t.Fatalf("reminderDelay is not valid JSON: %v", err)
+	}
+	if decoded.Value != 3 || decoded.Unit != "days" {
+		t.Errorf("reminderDelay = %+v, want {3 days}", decoded)
+	}
+	for _, key := range []string{"reminderInterval", "expireAfter", "expirationWarning", "expirationWarningInterval"} {
+		if formData[key] == "" {
+			t.Errorf("%s was not sent", key)
+		}
+	}
+}
+
+func TestApplyScheduleOverrides_OmitsUnsetFields(t *testing.T) {
+	formData := captureFormData(t, SignatureSchedule{})
+
+	for _, key := range []string{
+		"remindersEnabled", "reminderDelay", "reminderInterval", "maxReminders",
+		"expirationEnabled", "expireAfter", "expirationWarning", "expirationWarningInterval",
+	} {
+		if _, present := formData[key]; present {
+			t.Errorf("%s should be omitted so the org default applies, got %q", key, formData[key])
+		}
+	}
+}
+
+// The reason every field is a pointer: a deliberate false must survive, and Go's zero value
+// cannot express "unset" on its own.
+func TestApplyScheduleOverrides_SendsExplicitFalse(t *testing.T) {
+	formData := captureFormData(t, SignatureSchedule{
+		RemindersEnabled:  boolPtr(false),
+		ExpirationEnabled: boolPtr(false),
+	})
+
+	if formData["remindersEnabled"] != "false" {
+		t.Errorf("remindersEnabled = %q, want \"false\" (not dropped)", formData["remindersEnabled"])
+	}
+	if formData["expirationEnabled"] != "false" {
+		t.Errorf("expirationEnabled = %q, want \"false\" (not dropped)", formData["expirationEnabled"])
+	}
+}
+
+func TestApplyScheduleOverrides_SendsZeroAndUnlimitedMaxReminders(t *testing.T) {
+	zero := captureFormData(t, SignatureSchedule{MaxReminders: intPtr(0)})
+	if zero["maxReminders"] != "0" {
+		t.Errorf("maxReminders = %q, want \"0\" (means no reminders)", zero["maxReminders"])
+	}
+
+	unlimited := captureFormData(t, SignatureSchedule{MaxReminders: intPtr(-1)})
+	if unlimited["maxReminders"] != "-1" {
+		t.Errorf("maxReminders = %q, want \"-1\" (means unlimited)", unlimited["maxReminders"])
+	}
+}
+
+// Zero is legal for the warning offset alone, and means "never warn".
+func TestApplyScheduleOverrides_SendsZeroExpirationWarning(t *testing.T) {
+	formData := captureFormData(t, SignatureSchedule{
+		ExpirationWarning: &Duration{Value: 0, Unit: "hours"},
+	})
+
+	var decoded Duration
+	if err := json.Unmarshal([]byte(formData["expirationWarning"]), &decoded); err != nil {
+		t.Fatalf("expirationWarning is not valid JSON: %v", err)
+	}
+	if decoded.Value != 0 || decoded.Unit != "hours" {
+		t.Errorf("expirationWarning = %+v, want {0 hours}", decoded)
+	}
+}
+
+func TestSendReminder(t *testing.T) {
+	tests := []struct {
+		name         string
+		recipientIDs []string
+		wantBodyKey  bool
+	}{
+		{"no ids remind every eligible signer", nil, false},
+		// An empty slice is a caller mistake the API would 400 on (min 1 when the key is
+		// present). Treat it as "no filter" rather than forwarding a request that cannot succeed.
+		{"empty slice is treated as unfiltered", []string{}, false},
+		{"named ids are passed through", []string{"r-1", "r-2"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody map[string]interface{}
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"results":[{"recipientId":"r-1","status":"sent","reminderCount":2,"phase":"reminder"}]}}`))
+			}))
+			defer server.Close()
+
+			client, _ := NewClientWithConfig(ClientConfig{
+				APIKey:      "test-api-key",
+				OrgID:       "test-org-id",
+				SenderEmail: "sender@company.com",
+				BaseURL:     server.URL,
+			})
+
+			resp, err := client.TurboSign.SendReminder(context.Background(), "doc-123", tc.recipientIDs)
+			if err != nil {
+				t.Fatalf("SendReminder returned an error: %v", err)
+			}
+
+			if gotPath != "/turbosign/documents/doc-123/send-reminder" {
+				t.Errorf("path = %q", gotPath)
+			}
+			_, present := gotBody["recipientIds"]
+			if present != tc.wantBodyKey {
+				t.Errorf("recipientIds present = %v, want %v (body: %v)", present, tc.wantBodyKey, gotBody)
+			}
+			if len(resp.Results) != 1 || resp.Results[0].Status != "sent" {
+				t.Errorf("results = %+v, want one 'sent' entry", resp.Results)
+			}
+			if resp.Results[0].ReminderCount != 2 {
+				t.Errorf("reminderCount = %d, want 2", resp.Results[0].ReminderCount)
+			}
+		})
+	}
+}

--- a/packages/java-sdk/src/main/java/com/turbodocx/TurboSign.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/TurboSign.java
@@ -38,7 +38,8 @@ public final class TurboSign {
                 request.getDocumentDescription(),
                 request.getSenderName(),
                 request.getSenderEmail(),
-                request.getCcEmails()
+                request.getCcEmails(),
+                request.getSchedule()
         );
 
         if (request.hasFile()) {
@@ -81,7 +82,8 @@ public final class TurboSign {
                 request.getDocumentDescription(),
                 request.getSenderName(),
                 request.getSenderEmail(),
-                request.getCcEmails()
+                request.getCcEmails(),
+                request.getSchedule()
         );
 
         if (request.hasFile()) {
@@ -210,7 +212,8 @@ public final class TurboSign {
             String documentDescription,
             String senderName,
             String senderEmail,
-            List<String> ccEmails
+            List<String> ccEmails,
+            SignatureSchedule schedule
     ) {
         Map<String, String> formData = new HashMap<>();
         formData.put("recipients", gson.toJson(recipients));
@@ -237,6 +240,88 @@ public final class TurboSign {
             formData.put("ccEmails", gson.toJson(ccEmails));
         }
 
+        applyScheduleOverrides(formData, schedule);
+
         return formData;
+    }
+
+    /**
+     * Copies per-document reminder/expiration overrides onto an outgoing request body.
+     *
+     * <p>Durations are JSON-encoded. multipart/form-data has no notion of a nested value, so a
+     * {value, unit} object cannot survive the file-upload path as an object. The API decodes a
+     * JSON-string duration on both content types, so encoding uniformly keeps one code path for
+     * the multipart and JSON branches — the same treatment recipients and fields already get.
+     *
+     * <p>Scalars are formatted as strings because formData is {@code Map<String, String>}; the
+     * API's validation coerces them, exactly as it already does for the JSON-encoded recipients,
+     * fields and ccEmails this SDK sends.
+     *
+     * <p>Null checks, never truthiness: a deliberate {@code false} or {@code 0} must survive.
+     */
+    private void applyScheduleOverrides(Map<String, String> formData, SignatureSchedule schedule) {
+        if (schedule == null) {
+            return;
+        }
+
+        if (schedule.getRemindersEnabled() != null) {
+            formData.put("remindersEnabled", String.valueOf(schedule.getRemindersEnabled()));
+        }
+        if (schedule.getMaxReminders() != null) {
+            formData.put("maxReminders", String.valueOf(schedule.getMaxReminders()));
+        }
+        if (schedule.getExpirationEnabled() != null) {
+            formData.put("expirationEnabled", String.valueOf(schedule.getExpirationEnabled()));
+        }
+
+        putDuration(formData, "reminderDelay", schedule.getReminderDelay());
+        putDuration(formData, "reminderInterval", schedule.getReminderInterval());
+        putDuration(formData, "expireAfter", schedule.getExpireAfter());
+        putDuration(formData, "expirationWarning", schedule.getExpirationWarning());
+        putDuration(formData, "expirationWarningInterval", schedule.getExpirationWarningInterval());
+    }
+
+    private void putDuration(Map<String, String> formData, String key, SignatureSchedule.Duration duration) {
+        if (duration != null) {
+            formData.put(key, gson.toJson(duration));
+        }
+    }
+
+    /**
+     * Sends a reminder email to a document's outstanding signers.
+     *
+     * <p>This is a standalone nudge, deliberately decoupled from the automatic reminder schedule:
+     * it ignores the configured cadence, works even when reminders are disabled or the per-signer
+     * cap is already spent, and does not consume that cap.
+     *
+     * <p>Only signers at the CURRENT signing order are emailed. A recipient at a later order (or
+     * one who has already signed) is reported back as skipped rather than silently dropped.
+     *
+     * @param documentId   ID of the document
+     * @param recipientIds optional subset to remind; pass null to remind every eligible signer.
+     *                     When supplied the request is all-or-nothing: if any id is not a
+     *                     current-order pending signer the API rejects the whole call.
+     * @return one result per recipient considered
+     * @throws IOException on transport failure
+     */
+    public SendReminderResponse sendReminder(String documentId, List<String> recipientIds) throws IOException {
+        // Only include the filter when it actually names someone. The API requires at least one
+        // id when the key is present, so forwarding an empty list would guarantee a 400 — an
+        // empty list is far more likely to mean "no filter" than "remind nobody".
+        Map<String, Object> body = new HashMap<>();
+        if (recipientIds != null && !recipientIds.isEmpty()) {
+            body.put("recipientIds", recipientIds);
+        }
+
+        return httpClient.post(
+                "/turbosign/documents/" + documentId + "/send-reminder",
+                body,
+                SendReminderResponse.class
+        );
+    }
+
+    /** Reminds every eligible signer. @see #sendReminder(String, List) */
+    public SendReminderResponse sendReminder(String documentId) throws IOException {
+        return sendReminder(documentId, null);
     }
 }

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/CreateSignatureReviewLinkRequest.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/CreateSignatureReviewLinkRequest.java
@@ -18,8 +18,11 @@ public class CreateSignatureReviewLinkRequest {
     private final String senderName;
     private final String senderEmail;
     private final List<String> ccEmails;
+    /** Per-document reminder + expiration overrides; null inherits the org defaults. */
+    private final SignatureSchedule schedule;
 
     private CreateSignatureReviewLinkRequest(Builder builder) {
+        this.schedule = builder.schedule;
         this.file = builder.file;
         this.fileName = builder.fileName;
         this.fileLink = builder.fileLink;
@@ -82,6 +85,10 @@ public class CreateSignatureReviewLinkRequest {
         return ccEmails;
     }
 
+    public SignatureSchedule getSchedule() {
+        return schedule;
+    }
+
     public boolean hasFile() {
         return file != null && file.length > 0;
     }
@@ -99,6 +106,7 @@ public class CreateSignatureReviewLinkRequest {
         private String senderName;
         private String senderEmail;
         private List<String> ccEmails;
+        private SignatureSchedule schedule;
 
         public Builder file(byte[] file) {
             this.file = file;
@@ -157,6 +165,12 @@ public class CreateSignatureReviewLinkRequest {
 
         public Builder ccEmails(List<String> ccEmails) {
             this.ccEmails = ccEmails;
+            return this;
+        }
+
+        /** Per-document reminder + expiration overrides. Omit to inherit the org defaults. */
+        public Builder schedule(SignatureSchedule schedule) {
+            this.schedule = schedule;
             return this;
         }
 

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/SendReminderResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/SendReminderResponse.java
@@ -1,0 +1,45 @@
+package com.turbodocx.models;
+
+import java.util.List;
+
+/**
+ * Response from {@code TurboSign.sendReminder}.
+ *
+ * <p>Carries one entry per recipient considered, including those skipped and why — a later-order
+ * signer is reported rather than silently dropped, so the caller can tell nobody was emailed.
+ */
+public class SendReminderResponse {
+
+    /** Outcome for one recipient of a reminder request. */
+    public static class ReminderResult {
+        private String recipientId;
+        private String status;
+        private Integer reminderCount;
+        private String phase;
+
+        public String getRecipientId() {
+            return recipientId;
+        }
+
+        /** e.g. "sent", "skipped_wrong_order", "skipped_completed". */
+        public String getStatus() {
+            return status;
+        }
+
+        /** Reminder count after the send; only meaningful when the status is "sent". */
+        public Integer getReminderCount() {
+            return reminderCount;
+        }
+
+        /** Which email was sent — "reminder" or "expiring". */
+        public String getPhase() {
+            return phase;
+        }
+    }
+
+    private List<ReminderResult> results;
+
+    public List<ReminderResult> getResults() {
+        return results;
+    }
+}

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/SendSignatureRequest.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/SendSignatureRequest.java
@@ -18,8 +18,11 @@ public class SendSignatureRequest {
     private final String senderName;
     private final String senderEmail;
     private final List<String> ccEmails;
+    /** Per-document reminder + expiration overrides; null inherits the org defaults. */
+    private final SignatureSchedule schedule;
 
     private SendSignatureRequest(Builder builder) {
+        this.schedule = builder.schedule;
         this.file = builder.file;
         this.fileName = builder.fileName;
         this.fileLink = builder.fileLink;
@@ -82,6 +85,10 @@ public class SendSignatureRequest {
         return ccEmails;
     }
 
+    public SignatureSchedule getSchedule() {
+        return schedule;
+    }
+
     public boolean hasFile() {
         return file != null && file.length > 0;
     }
@@ -99,6 +106,7 @@ public class SendSignatureRequest {
         private String senderName;
         private String senderEmail;
         private List<String> ccEmails;
+        private SignatureSchedule schedule;
 
         public Builder file(byte[] file) {
             this.file = file;
@@ -157,6 +165,12 @@ public class SendSignatureRequest {
 
         public Builder ccEmails(List<String> ccEmails) {
             this.ccEmails = ccEmails;
+            return this;
+        }
+
+        /** Per-document reminder + expiration overrides. Omit to inherit the org defaults. */
+        public Builder schedule(SignatureSchedule schedule) {
+            this.schedule = schedule;
             return this;
         }
 

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/SignatureSchedule.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/SignatureSchedule.java
@@ -1,0 +1,158 @@
+package com.turbodocx.models;
+
+/**
+ * Per-document reminder + expiration overrides.
+ *
+ * <p>Every field is a boxed type so {@code null} stays distinguishable from a deliberate
+ * {@code false} or {@code 0}: reminders-off, a cap of 0 (no reminders) and a cap of -1
+ * (unlimited) are all meaningful, and a primitive's default would silently fall back to the
+ * organization's default — the opposite of what the caller asked for.
+ *
+ * <p>An omitted field inherits the org default; omitting the whole schedule means "use the org
+ * policy as it stands at send time". Both reminders and expiration are off by default.
+ */
+public class SignatureSchedule {
+
+    /** A configured length of time. The unit is carried alongside the value, not normalised away. */
+    public static class Duration {
+        private final int value;
+        private final String unit;
+
+        /**
+         * @param value whole number of units; minimum 1, except an expiration warning where 0
+         *              means "never warn"
+         * @param unit  "hours" or "days"
+         */
+        public Duration(int value, String unit) {
+            this.value = value;
+            this.unit = unit;
+        }
+
+        public int getValue() {
+            return value;
+        }
+
+        public String getUnit() {
+            return unit;
+        }
+    }
+
+    private final Boolean remindersEnabled;
+    private final Duration reminderDelay;
+    private final Duration reminderInterval;
+    private final Integer maxReminders;
+    private final Boolean expirationEnabled;
+    private final Duration expireAfter;
+    private final Duration expirationWarning;
+    private final Duration expirationWarningInterval;
+
+    private SignatureSchedule(Builder builder) {
+        this.remindersEnabled = builder.remindersEnabled;
+        this.reminderDelay = builder.reminderDelay;
+        this.reminderInterval = builder.reminderInterval;
+        this.maxReminders = builder.maxReminders;
+        this.expirationEnabled = builder.expirationEnabled;
+        this.expireAfter = builder.expireAfter;
+        this.expirationWarning = builder.expirationWarning;
+        this.expirationWarningInterval = builder.expirationWarningInterval;
+    }
+
+    public Boolean getRemindersEnabled() {
+        return remindersEnabled;
+    }
+
+    public Duration getReminderDelay() {
+        return reminderDelay;
+    }
+
+    public Duration getReminderInterval() {
+        return reminderInterval;
+    }
+
+    public Integer getMaxReminders() {
+        return maxReminders;
+    }
+
+    public Boolean getExpirationEnabled() {
+        return expirationEnabled;
+    }
+
+    public Duration getExpireAfter() {
+        return expireAfter;
+    }
+
+    public Duration getExpirationWarning() {
+        return expirationWarning;
+    }
+
+    public Duration getExpirationWarningInterval() {
+        return expirationWarningInterval;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private Boolean remindersEnabled;
+        private Duration reminderDelay;
+        private Duration reminderInterval;
+        private Integer maxReminders;
+        private Boolean expirationEnabled;
+        private Duration expireAfter;
+        private Duration expirationWarning;
+        private Duration expirationWarningInterval;
+
+        /** Send reminder emails to signers who haven't signed yet. */
+        public Builder remindersEnabled(Boolean remindersEnabled) {
+            this.remindersEnabled = remindersEnabled;
+            return this;
+        }
+
+        /** How long after the invitation before the FIRST reminder. */
+        public Builder reminderDelay(Duration reminderDelay) {
+            this.reminderDelay = reminderDelay;
+            return this;
+        }
+
+        /** Gap between subsequent reminders. */
+        public Builder reminderInterval(Duration reminderInterval) {
+            this.reminderInterval = reminderInterval;
+            return this;
+        }
+
+        /** Cap per signer. -1 means unlimited, 0 means none. Never caps expiry warnings. */
+        public Builder maxReminders(Integer maxReminders) {
+            this.maxReminders = maxReminders;
+            return this;
+        }
+
+        /** Close the signing window after {@code expireAfter}. */
+        public Builder expirationEnabled(Boolean expirationEnabled) {
+            this.expirationEnabled = expirationEnabled;
+            return this;
+        }
+
+        /** How long the document stays signable, counted from sending. */
+        public Builder expireAfter(Duration expireAfter) {
+            this.expireAfter = expireAfter;
+            return this;
+        }
+
+        /** How far BEFORE expiry warnings start. A zero value means no warnings at all. */
+        public Builder expirationWarning(Duration expirationWarning) {
+            this.expirationWarning = expirationWarning;
+            return this;
+        }
+
+        /** Gap between warnings once the warning window is open. */
+        public Builder expirationWarningInterval(Duration expirationWarningInterval) {
+            this.expirationWarningInterval = expirationWarningInterval;
+            return this;
+        }
+
+        public SignatureSchedule build() {
+            return new SignatureSchedule(this);
+        }
+    }
+}

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboSignScheduleTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboSignScheduleTest.java
@@ -1,0 +1,116 @@
+package com.turbodocx;
+
+import com.turbodocx.models.SendSignatureRequest;
+import com.turbodocx.models.SignatureSchedule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * TurboSign reminder + expiration schedule tests.
+ *
+ * <p>Mirrors the js-sdk, py-sdk, go-sdk, php-sdk and ruby-sdk suites, per the cross-SDK
+ * test-parity rule.
+ *
+ * <p>The load-bearing detail these lock in is that every schedule field is a BOXED type. A
+ * primitive {@code boolean}/{@code int} could not express "unset", so a deliberate
+ * reminders-off or a cap of 0 would be indistinguishable from an omitted field and would
+ * silently fall back to the organization's default.
+ */
+class TurboSignScheduleTest {
+
+    @Test
+    @DisplayName("carries every schedule field onto the request")
+    void carriesEveryScheduleField() {
+        SignatureSchedule schedule = SignatureSchedule.builder()
+                .remindersEnabled(true)
+                .reminderDelay(new SignatureSchedule.Duration(3, "days"))
+                .reminderInterval(new SignatureSchedule.Duration(12, "hours"))
+                .maxReminders(5)
+                .expirationEnabled(true)
+                .expireAfter(new SignatureSchedule.Duration(30, "days"))
+                .expirationWarning(new SignatureSchedule.Duration(3, "days"))
+                .expirationWarningInterval(new SignatureSchedule.Duration(1, "days"))
+                .build();
+
+        assertTrue(schedule.getRemindersEnabled());
+        assertEquals(5, schedule.getMaxReminders());
+        assertTrue(schedule.getExpirationEnabled());
+        assertEquals(3, schedule.getReminderDelay().getValue());
+        assertEquals("days", schedule.getReminderDelay().getUnit());
+        assertEquals(12, schedule.getReminderInterval().getValue());
+        assertEquals("hours", schedule.getReminderInterval().getUnit());
+        assertEquals(30, schedule.getExpireAfter().getValue());
+        assertEquals(1, schedule.getExpirationWarningInterval().getValue());
+    }
+
+    @Test
+    @DisplayName("leaves every unset field null so the org default applies")
+    void leavesUnsetFieldsNull() {
+        SignatureSchedule schedule = SignatureSchedule.builder().build();
+
+        assertNull(schedule.getRemindersEnabled());
+        assertNull(schedule.getReminderDelay());
+        assertNull(schedule.getReminderInterval());
+        assertNull(schedule.getMaxReminders());
+        assertNull(schedule.getExpirationEnabled());
+        assertNull(schedule.getExpireAfter());
+        assertNull(schedule.getExpirationWarning());
+        assertNull(schedule.getExpirationWarningInterval());
+    }
+
+    // The reason the fields are boxed: a deliberate "off" must survive as false, not vanish.
+    @Test
+    @DisplayName("keeps an explicit false distinct from unset")
+    void keepsExplicitFalseDistinctFromUnset() {
+        SignatureSchedule off = SignatureSchedule.builder()
+                .remindersEnabled(false)
+                .expirationEnabled(false)
+                .build();
+
+        assertFalse(off.getRemindersEnabled());
+        assertFalse(off.getExpirationEnabled());
+        assertNull(SignatureSchedule.builder().build().getRemindersEnabled());
+    }
+
+    @Test
+    @DisplayName("keeps a cap of 0 (none) and -1 (unlimited) distinct from unset")
+    void keepsZeroAndUnlimitedCapsDistinctFromUnset() {
+        assertEquals(0, SignatureSchedule.builder().maxReminders(0).build().getMaxReminders());
+        assertEquals(-1, SignatureSchedule.builder().maxReminders(-1).build().getMaxReminders());
+        assertNull(SignatureSchedule.builder().build().getMaxReminders());
+    }
+
+    // Zero is legal for the warning offset alone, and means "never warn".
+    @Test
+    @DisplayName("allows a zero expiration warning, meaning no warning emails")
+    void allowsZeroExpirationWarning() {
+        SignatureSchedule schedule = SignatureSchedule.builder()
+                .expirationWarning(new SignatureSchedule.Duration(0, "hours"))
+                .build();
+
+        assertEquals(0, schedule.getExpirationWarning().getValue());
+        assertEquals("hours", schedule.getExpirationWarning().getUnit());
+    }
+
+    @Test
+    @DisplayName("attaches the schedule to a send request, and leaves it null when unset")
+    void attachesScheduleToRequest() {
+        SignatureSchedule schedule = SignatureSchedule.builder().remindersEnabled(true).build();
+
+        SendSignatureRequest withSchedule = new SendSignatureRequest.Builder()
+                .deliverableId("deliv-1")
+                .schedule(schedule)
+                .build();
+        assertTrue(withSchedule.getSchedule().getRemindersEnabled());
+
+        SendSignatureRequest withoutSchedule = new SendSignatureRequest.Builder()
+                .deliverableId("deliv-1")
+                .build();
+        assertNull(withoutSchedule.getSchedule(), "an unset schedule must stay null so org defaults apply");
+    }
+}

--- a/packages/js-sdk/examples/turbosign-reminders-expiration.ts
+++ b/packages/js-sdk/examples/turbosign-reminders-expiration.ts
@@ -1,0 +1,108 @@
+/**
+ * TurboSign SDK - Reminders & Expiration Example
+ *
+ * This example demonstrates the per-document reminder + expiration schedule and the
+ * standalone reminder nudge:
+ * 1. Configure the SDK
+ * 2. Send a document WITH a reminder cadence and an expiry deadline
+ * 3. Read the deadline back off the status endpoint
+ * 4. Nudge whoever's turn it is to sign
+ * 5. Handle a recipient who isn't eligible for a reminder
+ *
+ * Run it:
+ *   TURBODOCX_API_KEY=... TURBODOCX_ORG_ID=... TURBODOCX_SENDER_EMAIL=... \
+ *   EXAMPLE_DELIVERABLE_ID=... npx ts-node examples/turbosign-reminders-expiration.ts
+ */
+
+import { TurboSign } from '../src';
+import type { Recipient, Field } from '../src/types/sign';
+
+async function main() {
+  // 1. Configure with your API credentials
+  TurboSign.configure({
+    apiKey: process.env.TURBODOCX_API_KEY!,
+    orgId: process.env.TURBODOCX_ORG_ID!,
+    senderEmail: process.env.TURBODOCX_SENDER_EMAIL!,
+    senderName: 'Reminders Example',
+  });
+
+  const recipients: Recipient[] = [
+    { name: 'Example Signer', email: 'signer@example.com', signingOrder: 1 },
+  ];
+
+  const fields: Field[] = [
+    {
+      type: 'signature',
+      page: 1,
+      x: 100,
+      y: 500,
+      width: 200,
+      height: 50,
+      recipientEmail: 'signer@example.com',
+    },
+  ];
+
+  // 2. Send with a schedule.
+  //
+  // Every schedule field is optional — omit one and it inherits your organization's
+  // E-Signature default. Both reminders and expiration ship OFF by default, so a send with
+  // none of these fields behaves exactly as it always has.
+  //
+  // Durations are `{ value, unit }`. They are JSON-encoded on the wire because
+  // multipart/form-data (the file-upload path) cannot carry a nested value — the SDK handles
+  // that for you on both the multipart and JSON paths.
+  console.log('Sending with a reminder + expiration schedule...');
+  const sent = await TurboSign.sendSignature({
+    deliverableId: process.env.EXAMPLE_DELIVERABLE_ID!,
+    recipients,
+    fields,
+    documentName: 'Reminders & Expiration Example',
+    documentDescription: 'Demonstrates the per-document schedule.',
+
+    // Reminders — chase the signer until they act, or until the cap is spent.
+    remindersEnabled: true,
+    reminderDelay: { value: 2, unit: 'days' },     // time to the FIRST reminder
+    reminderInterval: { value: 1, unit: 'days' },  // gap between later ones
+    maxReminders: 3,                               // -1 = unlimited, 0 = none
+
+    // Expiration — close the signing window, and warn before it shuts.
+    expirationEnabled: true,
+    expireAfter: { value: 14, unit: 'days' },
+    expirationWarning: { value: 2, unit: 'days' },         // 0 = never warn
+    expirationWarningInterval: { value: 1, unit: 'days' },
+  });
+  console.log('  documentId:', sent.documentId, '| status:', sent.status);
+
+  // 3. The deadline is frozen onto the document at send time, so later changes to your org
+  //    defaults never move it. Read it back off the status endpoint.
+  const status = await TurboSign.getStatus(sent.documentId);
+  console.log('  status:', status.status);
+  console.log('  expiresAt:', status.expiresAt ?? '(never — expiration is off)');
+
+  // 4. Nudge whoever's turn it is.
+  //
+  // This is a STANDALONE nudge: it ignores the cadence above, works even when reminders are
+  // disabled or the cap is spent, and does not consume that cap. Omit the recipient ids to
+  // remind everyone eligible — do NOT pass an empty array, which the API rejects.
+  console.log('Sending a reminder...');
+  const { results } = await TurboSign.sendReminder(sent.documentId);
+  for (const result of results) {
+    // Only signers at the CURRENT signing order are emailed. Anyone else comes back as a
+    // `skipped_*` status rather than being silently dropped, so you can tell whether anyone
+    // actually received something.
+    console.log(`  ${result.recipientId}: ${result.status}`);
+  }
+
+  // 5. Naming an ineligible recipient is all-or-nothing: the API rejects the whole request
+  //    and sends nothing, rather than partially succeeding.
+  try {
+    await TurboSign.sendReminder(sent.documentId, ['00000000-0000-4000-8000-000000000001']);
+  } catch (error) {
+    console.log('  ineligible recipient correctly rejected:', (error as Error).message);
+  }
+}
+
+main().catch((error) => {
+  console.error('Example failed:', error);
+  process.exit(1);
+});

--- a/packages/js-sdk/src/modules/sign.ts
+++ b/packages/js-sdk/src/modules/sign.ts
@@ -13,6 +13,8 @@ import {
   CreateSignatureReviewLinkResponse,
   SendSignatureRequest,
   SendSignatureResponse,
+  SignatureScheduleOptions,
+  SendReminderResponse,
 } from '../types/sign';
 
 export class TurboSign {
@@ -56,6 +58,42 @@ export class TurboSign {
   // ============================================
   // SINGLE-STEP OPERATIONS
   // ============================================
+
+  /**
+   * Copies any per-document schedule overrides onto an outgoing request body.
+   *
+   * Durations are JSON-encoded. `multipart/form-data` has no notion of a nested value — every
+   * part arrives as a string — so a `{ value, unit }` object cannot survive the file-upload path
+   * as an object. The API decodes a JSON-string duration on BOTH content types, so encoding
+   * uniformly keeps one code path for the multipart and JSON branches, exactly as `recipients`
+   * and `fields` are already handled.
+   *
+   * Presence is tested with `!== undefined`, never truthiness: `false` (feature off) and `0`
+   * (no reminders / never warn) are all meaningful values, and a truthiness check would drop
+   * them and silently fall back to the organization's default — the opposite of what the caller
+   * asked for.
+   */
+  private static applyScheduleOverrides(
+    formData: Record<string, any>,
+    request: SignatureScheduleOptions
+  ): void {
+    if (request.remindersEnabled !== undefined) formData.remindersEnabled = request.remindersEnabled;
+    if (request.maxReminders !== undefined) formData.maxReminders = request.maxReminders;
+    if (request.expirationEnabled !== undefined) formData.expirationEnabled = request.expirationEnabled;
+
+    const durationFields = [
+      'reminderDelay',
+      'reminderInterval',
+      'expireAfter',
+      'expirationWarning',
+      'expirationWarningInterval',
+    ] as const;
+
+    for (const field of durationFields) {
+      const duration = request[field];
+      if (duration !== undefined) formData[field] = JSON.stringify(duration);
+    }
+  }
 
   /**
    * Create signature review link without sending emails
@@ -122,6 +160,9 @@ export class TurboSign {
         ? JSON.stringify(request.ccEmails)
         : JSON.stringify([request.ccEmails]);
     }
+
+    // Per-document reminder + expiration overrides; omitted keys inherit the org defaults.
+    this.applyScheduleOverrides(formData, request);
 
     // Handle different file input methods
     if (request.file) {
@@ -203,6 +244,9 @@ export class TurboSign {
         ? JSON.stringify(request.ccEmails)
         : JSON.stringify([request.ccEmails]);
     }
+
+    // Per-document reminder + expiration overrides; omitted keys inherit the org defaults.
+    this.applyScheduleOverrides(formData, request);
 
     // Handle different file input methods
     if (request.file) {
@@ -348,5 +392,56 @@ export class TurboSign {
     const client = this.getClient();
     // HTTP client auto-unwraps {data: ...} responses
     return client.get<DocumentStatusResponse>(`/turbosign/documents/${documentId}/status`);
+  }
+
+  /**
+   * Send a reminder email to a document's outstanding signers
+   *
+   * This is a **standalone nudge**, deliberately decoupled from the automatic reminder schedule:
+   * it ignores the configured cadence, works even when reminders are disabled or the per-signer
+   * cap is already spent, and does not consume that cap.
+   *
+   * Only signers at the CURRENT signing order are emailed. A recipient at a later order (or one
+   * who has already signed) is reported back as skipped rather than silently dropped, so the
+   * caller can tell that nobody was emailed.
+   *
+   * @param documentId - ID of the document
+   * @param recipientIds - Optional subset to remind. Omit to remind every eligible signer.
+   *                       When supplied, the request is all-or-nothing: if any id is not a
+   *                       current-order pending signer the API rejects the whole call and sends
+   *                       nothing.
+   * @returns One result per recipient considered, including why each was skipped
+   *
+   * @example
+   * ```typescript
+   * // Nudge whoever's turn it is
+   * const { results } = await TurboSign.sendReminder(documentId);
+   * for (const r of results) {
+   *   console.log(`${r.recipientId}: ${r.status}`); // e.g. "sent", "skipped_wrong_order"
+   * }
+   *
+   * // Nudge one specific signer
+   * await TurboSign.sendReminder(documentId, [recipientId]);
+   * ```
+   */
+  static async sendReminder(
+    documentId: string,
+    recipientIds?: string[]
+  ): Promise<SendReminderResponse> {
+    const client = this.getClient();
+
+    // Only include the filter when it actually names someone. The API requires at least one id
+    // when the key is present, so forwarding an empty array would guarantee a 400 — an empty
+    // list is far more likely to mean "no filter" than "remind nobody".
+    const body: Record<string, unknown> = {};
+    if (recipientIds && recipientIds.length > 0) {
+      body.recipientIds = recipientIds;
+    }
+
+    // HTTP client auto-unwraps {data: ...} responses
+    return client.post<SendReminderResponse>(
+      `/turbosign/documents/${documentId}/send-reminder`,
+      body
+    );
   }
 }

--- a/packages/js-sdk/src/types/sign.ts
+++ b/packages/js-sdk/src/types/sign.ts
@@ -109,8 +109,89 @@ export interface AuditTrailResponse {
 }
 
 export interface DocumentStatusResponse {
-  /** Current document status */
+  /** Current document status — e.g. 'under_review', 'completed', 'voided', 'expired' */
   status: string;
+  /**
+   * ISO timestamp when the signing window closes, if the document has a deadline.
+   *
+   * Absent when expiration is off (the default), which means the document never expires.
+   * Once this instant passes the signing links stop working and the document becomes 'expired'.
+   */
+  expiresAt?: string;
+}
+
+// ============================================
+// REMINDER + EXPIRATION SCHEDULE
+// ============================================
+
+/**
+ * A configured length of time.
+ *
+ * The unit is carried alongside the value rather than normalised away, so "48 hours" stays
+ * "48 hours" instead of reading back as "2 days".
+ */
+export interface Duration {
+  /** Whole number of units. Minimum 1, except `expirationWarning` where 0 means "never warn". */
+  value: number;
+  /** Unit the value is measured in */
+  unit: 'hours' | 'days';
+}
+
+/**
+ * Per-document reminder + expiration overrides.
+ *
+ * Every field is optional. An omitted field inherits the organization's default; omitting the set
+ * entirely means "use the org policy as it stands at send time". Both features are **off** by
+ * default, so a document only gets reminders or an expiry if the org enabled them or the caller
+ * opts in here.
+ *
+ * The resolved schedule is frozen onto the document when it is sent, so later changes to the org
+ * defaults never alter a document already out for signature.
+ */
+export interface SignatureScheduleOptions {
+  /** Send reminder emails to signers who haven't signed yet */
+  remindersEnabled?: boolean;
+  /** How long after the invitation before the FIRST reminder */
+  reminderDelay?: Duration;
+  /** Gap between subsequent reminders */
+  reminderInterval?: Duration;
+  /** Cap per signer. `-1` means unlimited, `0` means none. Never caps expiry warnings. */
+  maxReminders?: number;
+  /** Close the signing window after `expireAfter` */
+  expirationEnabled?: boolean;
+  /** How long the document stays signable, counted from sending */
+  expireAfter?: Duration;
+  /** How far BEFORE expiry warning emails start. `{ value: 0 }` means no warnings at all. */
+  expirationWarning?: Duration;
+  /** Gap between warnings once the warning window is open */
+  expirationWarningInterval?: Duration;
+}
+
+/** Outcome for one recipient of a reminder request */
+export type ReminderStatus =
+  | 'sent'
+  | 'failed'
+  | 'skipped_not_due'
+  | 'skipped_max_reached'
+  | 'skipped_disabled'
+  | 'skipped_completed'
+  | 'skipped_wrong_order'
+  | 'skipped_claim_lost';
+
+export interface ReminderResult {
+  /** Recipient this outcome refers to */
+  recipientId: string;
+  /** What happened for this recipient */
+  status: ReminderStatus;
+  /** Reminder count after the send (only meaningful when status is 'sent') */
+  reminderCount?: number;
+  /** Which email was sent — the reminder nudge or the expiry warning */
+  phase?: 'reminder' | 'expiring';
+}
+
+export interface SendReminderResponse {
+  /** One entry per recipient considered, including those skipped and why */
+  results: ReminderResult[];
 }
 
 // ============================================
@@ -205,6 +286,18 @@ export interface CreateSignatureReviewLinkRequest {
   senderEmail?: string;
   /** CC emails (comma-separated or array) */
   ccEmails?: string | string[];
+  /**
+   * Per-document reminder + expiration overrides. Omit to inherit the organization's defaults.
+   * @see SignatureScheduleOptions
+   */
+  remindersEnabled?: SignatureScheduleOptions['remindersEnabled'];
+  reminderDelay?: SignatureScheduleOptions['reminderDelay'];
+  reminderInterval?: SignatureScheduleOptions['reminderInterval'];
+  maxReminders?: SignatureScheduleOptions['maxReminders'];
+  expirationEnabled?: SignatureScheduleOptions['expirationEnabled'];
+  expireAfter?: SignatureScheduleOptions['expireAfter'];
+  expirationWarning?: SignatureScheduleOptions['expirationWarning'];
+  expirationWarningInterval?: SignatureScheduleOptions['expirationWarningInterval'];
 }
 
 /**
@@ -253,6 +346,18 @@ export interface SendSignatureRequest {
   senderEmail?: string;
   /** CC emails (comma-separated or array) */
   ccEmails?: string | string[];
+  /**
+   * Per-document reminder + expiration overrides. Omit to inherit the organization's defaults.
+   * @see SignatureScheduleOptions
+   */
+  remindersEnabled?: SignatureScheduleOptions['remindersEnabled'];
+  reminderDelay?: SignatureScheduleOptions['reminderDelay'];
+  reminderInterval?: SignatureScheduleOptions['reminderInterval'];
+  maxReminders?: SignatureScheduleOptions['maxReminders'];
+  expirationEnabled?: SignatureScheduleOptions['expirationEnabled'];
+  expireAfter?: SignatureScheduleOptions['expireAfter'];
+  expirationWarning?: SignatureScheduleOptions['expirationWarning'];
+  expirationWarningInterval?: SignatureScheduleOptions['expirationWarningInterval'];
 }
 
 /**

--- a/packages/js-sdk/tests/turbosign-schedule.test.ts
+++ b/packages/js-sdk/tests/turbosign-schedule.test.ts
@@ -1,0 +1,277 @@
+/**
+ * TurboSign reminder + expiration schedule tests
+ *
+ * Covers the per-document schedule overrides that ride on both send paths, and the
+ * `sendReminder` operation.
+ *
+ * The API takes a duration as `{ value, unit }`. Both send endpoints accept multipart
+ * (file upload) and JSON (fileLink / deliverableId / templateId), and multipart has no notion of
+ * a nested value — so the SDK serializes each duration to a JSON string on BOTH paths, exactly as
+ * it already does for `recipients` and `fields`. The API decodes a JSON-string duration on either
+ * content type, so one code path serves both.
+ */
+
+import { TurboSign } from '../src/modules/sign';
+import { HttpClient } from '../src/http';
+import type { Recipient, Field } from '../src/types/sign';
+
+jest.mock('../src/http');
+
+const MockedHttpClient = HttpClient as jest.MockedClass<typeof HttpClient>;
+
+describe('TurboSign schedule overrides', () => {
+  const recipients: Recipient[] = [{ name: 'John Doe', email: 'john@example.com', signingOrder: 1 }];
+  const fields: Field[] = [
+    { type: 'signature', page: 1, x: 100, y: 500, width: 200, height: 50, recipientEmail: 'john@example.com' },
+  ];
+
+  let postMock: jest.Mock;
+  let getMock: jest.Mock;
+  let uploadMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (TurboSign as any).client = undefined;
+    // Stub the prototype BEFORE configure() — configure() constructs the client, and the
+    // auto-mocked instance captures its methods at construction time.
+    postMock = jest.fn().mockResolvedValue({});
+    getMock = jest.fn().mockResolvedValue({});
+    uploadMock = jest.fn().mockResolvedValue({});
+    MockedHttpClient.prototype.post = postMock;
+    MockedHttpClient.prototype.get = getMock;
+    MockedHttpClient.prototype.uploadFile = uploadMock;
+    MockedHttpClient.prototype.getSenderConfig = jest
+      .fn()
+      .mockReturnValue({ senderEmail: 'sender@company.com', senderName: 'Sender' });
+    TurboSign.configure({ apiKey: 'test-key', orgId: 'org-1', senderEmail: 'sender@company.com' });
+  });
+
+  describe('sendSignature — JSON path (deliverableId)', () => {
+    it('should send every schedule field the API accepts', async () => {
+      postMock.mockResolvedValue({ success: true, documentId: 'doc-1', status: 'under_review', message: 'ok' });
+
+      await TurboSign.sendSignature({
+        deliverableId: 'deliv-1',
+        recipients,
+        fields,
+        remindersEnabled: true,
+        reminderDelay: { value: 3, unit: 'days' },
+        reminderInterval: { value: 12, unit: 'hours' },
+        maxReminders: 5,
+        expirationEnabled: true,
+        expireAfter: { value: 30, unit: 'days' },
+        expirationWarning: { value: 3, unit: 'days' },
+        expirationWarningInterval: { value: 1, unit: 'days' },
+      });
+
+      const body = postMock.mock.calls[0][1];
+      expect(body.remindersEnabled).toBe(true);
+      expect(body.maxReminders).toBe(5);
+      expect(body.expirationEnabled).toBe(true);
+      // Durations are JSON-encoded — the API decodes them on both content types.
+      expect(body.reminderDelay).toBe('{"value":3,"unit":"days"}');
+      expect(body.reminderInterval).toBe('{"value":12,"unit":"hours"}');
+      expect(body.expireAfter).toBe('{"value":30,"unit":"days"}');
+      expect(body.expirationWarning).toBe('{"value":3,"unit":"days"}');
+      expect(body.expirationWarningInterval).toBe('{"value":1,"unit":"days"}');
+    });
+
+    it('should omit every schedule key when the caller sets none, so the org defaults apply', async () => {
+      postMock.mockResolvedValue({ success: true, documentId: 'doc-1', status: 'under_review', message: 'ok' });
+
+      await TurboSign.sendSignature({ deliverableId: 'deliv-1', recipients, fields });
+
+      const body = postMock.mock.calls[0][1];
+      for (const key of [
+        'remindersEnabled',
+        'reminderDelay',
+        'reminderInterval',
+        'maxReminders',
+        'expirationEnabled',
+        'expireAfter',
+        'expirationWarning',
+        'expirationWarningInterval',
+      ]) {
+        expect(body).not.toHaveProperty(key);
+      }
+    });
+
+    // `false` and `0` are meaningful values, not "unset" — a truthiness check would drop them and
+    // silently fall back to the org default, which is the opposite of what the caller asked for.
+    it('should send remindersEnabled:false rather than dropping it', async () => {
+      postMock.mockResolvedValue({ success: true, documentId: 'd', status: 's', message: 'ok' });
+
+      await TurboSign.sendSignature({ deliverableId: 'd', recipients, fields, remindersEnabled: false, expirationEnabled: false });
+
+      expect(postMock.mock.calls[0][1].remindersEnabled).toBe(false);
+      expect(postMock.mock.calls[0][1].expirationEnabled).toBe(false);
+    });
+
+    it('should send maxReminders:0 (no reminders) and -1 (unlimited) rather than dropping them', async () => {
+      postMock.mockResolvedValue({ success: true, documentId: 'd', status: 's', message: 'ok' });
+
+      await TurboSign.sendSignature({ deliverableId: 'd', recipients, fields, maxReminders: 0 });
+      expect(postMock.mock.calls[0][1].maxReminders).toBe(0);
+
+      await TurboSign.sendSignature({ deliverableId: 'd', recipients, fields, maxReminders: -1 });
+      expect(postMock.mock.calls[1][1].maxReminders).toBe(-1);
+    });
+
+    // Zero is legal for the warning offset alone, and means "never warn".
+    it('should send a zero expirationWarning, which means no warning emails', async () => {
+      postMock.mockResolvedValue({ success: true, documentId: 'd', status: 's', message: 'ok' });
+
+      await TurboSign.sendSignature({ deliverableId: 'd', recipients, fields, expirationWarning: { value: 0, unit: 'hours' } });
+
+      expect(postMock.mock.calls[0][1].expirationWarning).toBe('{"value":0,"unit":"hours"}');
+    });
+  });
+
+  describe('createSignatureReviewLink — multipart path (file upload)', () => {
+    it('should carry the schedule in the multipart form data', async () => {
+      uploadMock.mockResolvedValue({ success: true, documentId: 'doc-1', status: 'draft', message: 'ok' });
+
+      await TurboSign.createSignatureReviewLink({
+        file: Buffer.from('%PDF-1.4'),
+        fileName: 'contract.pdf',
+        recipients,
+        fields,
+        remindersEnabled: true,
+        reminderDelay: { value: 2, unit: 'days' },
+        expirationEnabled: true,
+        expireAfter: { value: 14, unit: 'days' },
+      });
+
+      const formData = uploadMock.mock.calls[0][3];
+      expect(formData.remindersEnabled).toBe(true);
+      expect(formData.reminderDelay).toBe('{"value":2,"unit":"days"}');
+      expect(formData.expireAfter).toBe('{"value":14,"unit":"days"}');
+    });
+  });
+});
+
+describe('TurboSign.sendReminder', () => {
+  let postMock: jest.Mock;
+  let getMock: jest.Mock;
+  let uploadMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (TurboSign as any).client = undefined;
+    // Stub the prototype BEFORE configure() — configure() constructs the client, and the
+    // auto-mocked instance captures its methods at construction time.
+    postMock = jest.fn().mockResolvedValue({});
+    getMock = jest.fn().mockResolvedValue({});
+    uploadMock = jest.fn().mockResolvedValue({});
+    MockedHttpClient.prototype.post = postMock;
+    MockedHttpClient.prototype.get = getMock;
+    MockedHttpClient.prototype.uploadFile = uploadMock;
+    MockedHttpClient.prototype.getSenderConfig = jest
+      .fn()
+      .mockReturnValue({ senderEmail: 'sender@company.com', senderName: 'Sender' });
+    TurboSign.configure({ apiKey: 'test-key', orgId: 'org-1', senderEmail: 'sender@company.com' });
+  });
+
+  it('should POST to the send-reminder endpoint for the given document', async () => {
+      postMock.mockResolvedValue({ results: [] });
+
+    await TurboSign.sendReminder('doc-123');
+
+    expect(postMock).toHaveBeenCalledWith('/turbosign/documents/doc-123/send-reminder', {});
+  });
+
+  it('should send an empty body when no recipients are named, so every due signer is reminded', async () => {
+      postMock.mockResolvedValue({ results: [] });
+
+    await TurboSign.sendReminder('doc-123');
+
+    // An empty `recipientIds` array would be REJECTED by the API (min 1); the key must be absent.
+    expect(postMock.mock.calls[0][1]).not.toHaveProperty('recipientIds');
+  });
+
+  it('should pass named recipient ids through when supplied', async () => {
+      postMock.mockResolvedValue({ results: [] });
+
+    await TurboSign.sendReminder('doc-123', ['r-1', 'r-2']);
+
+    expect(postMock).toHaveBeenCalledWith('/turbosign/documents/doc-123/send-reminder', {
+      recipientIds: ['r-1', 'r-2'],
+    });
+  });
+
+  // An empty array is a caller mistake the API would 400 on. Treat it as "no filter" instead of
+  // forwarding a request that cannot succeed.
+  it('should treat an empty recipient list as unfiltered rather than sending a rejected body', async () => {
+      postMock.mockResolvedValue({ results: [] });
+
+    await TurboSign.sendReminder('doc-123', []);
+
+    expect(postMock.mock.calls[0][1]).not.toHaveProperty('recipientIds');
+  });
+
+  it('should return the per-recipient results the API reports', async () => {
+    postMock.mockResolvedValue({
+      results: [
+        { recipientId: 'r-1', status: 'sent', reminderCount: 2, phase: 'reminder' },
+        { recipientId: 'r-2', status: 'skipped_wrong_order' },
+      ],
+    });
+
+    const result = await TurboSign.sendReminder('doc-123');
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0].status).toBe('sent');
+    expect(result.results[0].reminderCount).toBe(2);
+    // A later-order signer is reported, not silently dropped — the caller can tell nobody was emailed.
+    expect(result.results[1].status).toBe('skipped_wrong_order');
+  });
+});
+
+describe('TurboSign document expiry surface', () => {
+  let postMock: jest.Mock;
+  let getMock: jest.Mock;
+  let uploadMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (TurboSign as any).client = undefined;
+    // Stub the prototype BEFORE configure() — configure() constructs the client, and the
+    // auto-mocked instance captures its methods at construction time.
+    postMock = jest.fn().mockResolvedValue({});
+    getMock = jest.fn().mockResolvedValue({});
+    uploadMock = jest.fn().mockResolvedValue({});
+    MockedHttpClient.prototype.post = postMock;
+    MockedHttpClient.prototype.get = getMock;
+    MockedHttpClient.prototype.uploadFile = uploadMock;
+    MockedHttpClient.prototype.getSenderConfig = jest
+      .fn()
+      .mockReturnValue({ senderEmail: 'sender@company.com', senderName: 'Sender' });
+    TurboSign.configure({ apiKey: 'test-key', orgId: 'org-1', senderEmail: 'sender@company.com' });
+  });
+
+  it('should surface expiresAt on the status response when the document has a deadline', async () => {
+    getMock.mockResolvedValue({ status: 'under_review', expiresAt: '2026-08-02T23:59:59.000Z' });
+
+    const status = await TurboSign.getStatus('doc-1');
+
+    expect(status.expiresAt).toBe('2026-08-02T23:59:59.000Z');
+  });
+
+  // Expiration is opt-in, so most documents never expire and the key is simply absent.
+  it('should tolerate a status response with no expiresAt', async () => {
+    getMock.mockResolvedValue({ status: 'under_review' });
+
+    const status = await TurboSign.getStatus('doc-1');
+
+    expect(status.expiresAt).toBeUndefined();
+    expect(status.status).toBe('under_review');
+  });
+
+  it('should report the terminal expired status', async () => {
+    getMock.mockResolvedValue({ status: 'expired', expiresAt: '2026-01-01T00:00:00.000Z' });
+
+    const status = await TurboSign.getStatus('doc-1');
+
+    expect(status.status).toBe('expired');
+  });
+});

--- a/packages/php-sdk/src/TurboSign.php
+++ b/packages/php-sdk/src/TurboSign.php
@@ -116,6 +116,9 @@ final class TurboSign
             $formData['ccEmails'] = json_encode($request->ccEmails);
         }
 
+        // Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+        self::applyScheduleOverrides($formData, $request);
+
         // Handle different file input methods
         if ($request->file !== null) {
             // File upload - use multipart form
@@ -199,6 +202,9 @@ final class TurboSign
         if ($request->ccEmails !== null) {
             $formData['ccEmails'] = json_encode($request->ccEmails);
         }
+
+        // Per-document reminder + expiration overrides; omitted fields inherit the org defaults.
+        self::applyScheduleOverrides($formData, $request);
 
         // Handle different file input methods
         if ($request->file !== null) {
@@ -304,6 +310,79 @@ final class TurboSign
             ['reason' => $reason]
         );
         return VoidDocumentResponse::fromArray($response);
+    }
+
+    /**
+     * Copy per-document reminder/expiration overrides onto an outgoing request body.
+     *
+     * Durations are JSON-encoded. multipart/form-data has no notion of a nested value, so a
+     * {value, unit} array cannot survive the file-upload path as an object. The API decodes a
+     * JSON-string duration on both content types, so encoding uniformly keeps one code path for
+     * the multipart and JSON branches — the same treatment recipients and fields already get.
+     *
+     * Presence is tested with `!== null`, never truthiness: `false` (feature off) and `0`
+     * (no reminders / never warn) are meaningful values, and a truthiness check would drop them
+     * and silently fall back to the organization's default.
+     *
+     * @param array<string, mixed> $formData
+     * @param CreateSignatureReviewLinkRequest|SendSignatureRequest $request
+     */
+    private static function applyScheduleOverrides(array &$formData, object $request): void
+    {
+        if ($request->remindersEnabled !== null) {
+            $formData['remindersEnabled'] = $request->remindersEnabled;
+        }
+        if ($request->maxReminders !== null) {
+            $formData['maxReminders'] = $request->maxReminders;
+        }
+        if ($request->expirationEnabled !== null) {
+            $formData['expirationEnabled'] = $request->expirationEnabled;
+        }
+
+        $durations = [
+            'reminderDelay' => $request->reminderDelay,
+            'reminderInterval' => $request->reminderInterval,
+            'expireAfter' => $request->expireAfter,
+            'expirationWarning' => $request->expirationWarning,
+            'expirationWarningInterval' => $request->expirationWarningInterval,
+        ];
+        foreach ($durations as $key => $duration) {
+            if ($duration !== null) {
+                $formData[$key] = json_encode($duration);
+            }
+        }
+    }
+
+    /**
+     * Send a reminder email to a document's outstanding signers.
+     *
+     * This is a standalone nudge, deliberately decoupled from the automatic reminder schedule: it
+     * ignores the configured cadence, works even when reminders are disabled or the per-signer cap
+     * is already spent, and does not consume that cap.
+     *
+     * Only signers at the CURRENT signing order are emailed. A recipient at a later order (or one
+     * who has already signed) is reported back as skipped rather than silently dropped, so the
+     * caller can tell that nobody was emailed.
+     *
+     * @param string $documentId ID of the document
+     * @param array<string>|null $recipientIds Optional subset to remind. Omit to remind every
+     *     eligible signer. When supplied the request is all-or-nothing: if any id is not a
+     *     current-order pending signer the API rejects the whole call and sends nothing.
+     * @return array<string, mixed> Results, one entry per recipient considered
+     */
+    public static function sendReminder(string $documentId, ?array $recipientIds = null): array
+    {
+        $client = self::getClient();
+
+        // Only include the filter when it actually names someone. The API requires at least one
+        // id when the key is present, so forwarding an empty array would guarantee a 400 — an
+        // empty list is far more likely to mean "no filter" than "remind nobody".
+        $body = [];
+        if ($recipientIds !== null && count($recipientIds) > 0) {
+            $body['recipientIds'] = $recipientIds;
+        }
+
+        return $client->post("/turbosign/documents/{$documentId}/send-reminder", $body);
     }
 
     /**

--- a/packages/php-sdk/src/Types/Requests/CreateSignatureReviewLinkRequest.php
+++ b/packages/php-sdk/src/Types/Requests/CreateSignatureReviewLinkRequest.php
@@ -25,6 +25,15 @@ final class CreateSignatureReviewLinkRequest
      * @param string|null $senderName Sender name (overrides configured value)
      * @param string|null $senderEmail Sender email (overrides configured value)
      * @param array<string>|null $ccEmails CC emails
+     * @param bool|null $remindersEnabled Send reminder emails to signers who haven't signed
+     * @param array{value:int,unit:string}|null $reminderDelay Time to the FIRST reminder
+     * @param array{value:int,unit:string}|null $reminderInterval Gap between later reminders
+     * @param int|null $maxReminders Cap per signer. -1 unlimited, 0 none. Never caps warnings.
+     * @param bool|null $expirationEnabled Close the signing window after $expireAfter
+     * @param array{value:int,unit:string}|null $expireAfter How long the document stays signable
+     * @param array{value:int,unit:string}|null $expirationWarning How far before expiry warnings
+     *     start. A zero value means no warnings at all.
+     * @param array{value:int,unit:string}|null $expirationWarningInterval Gap between warnings
      */
     public function __construct(
         public array $recipients,
@@ -39,5 +48,13 @@ final class CreateSignatureReviewLinkRequest
         public ?string $senderName = null,
         public ?string $senderEmail = null,
         public ?array $ccEmails = null,
+        public ?bool $remindersEnabled = null,
+        public ?array $reminderDelay = null,
+        public ?array $reminderInterval = null,
+        public ?int $maxReminders = null,
+        public ?bool $expirationEnabled = null,
+        public ?array $expireAfter = null,
+        public ?array $expirationWarning = null,
+        public ?array $expirationWarningInterval = null,
     ) {}
 }

--- a/packages/php-sdk/src/Types/Requests/SendSignatureRequest.php
+++ b/packages/php-sdk/src/Types/Requests/SendSignatureRequest.php
@@ -25,6 +25,15 @@ final class SendSignatureRequest
      * @param string|null $senderName Sender name (overrides configured value)
      * @param string|null $senderEmail Sender email (overrides configured value)
      * @param array<string>|null $ccEmails CC emails
+     * @param bool|null $remindersEnabled Send reminder emails to signers who haven't signed
+     * @param array{value:int,unit:string}|null $reminderDelay Time to the FIRST reminder
+     * @param array{value:int,unit:string}|null $reminderInterval Gap between later reminders
+     * @param int|null $maxReminders Cap per signer. -1 unlimited, 0 none. Never caps warnings.
+     * @param bool|null $expirationEnabled Close the signing window after $expireAfter
+     * @param array{value:int,unit:string}|null $expireAfter How long the document stays signable
+     * @param array{value:int,unit:string}|null $expirationWarning How far before expiry warnings
+     *     start. A zero value means no warnings at all.
+     * @param array{value:int,unit:string}|null $expirationWarningInterval Gap between warnings
      */
     public function __construct(
         public array $recipients,
@@ -39,5 +48,13 @@ final class SendSignatureRequest
         public ?string $senderName = null,
         public ?string $senderEmail = null,
         public ?array $ccEmails = null,
+        public ?bool $remindersEnabled = null,
+        public ?array $reminderDelay = null,
+        public ?array $reminderInterval = null,
+        public ?int $maxReminders = null,
+        public ?bool $expirationEnabled = null,
+        public ?array $expireAfter = null,
+        public ?array $expirationWarning = null,
+        public ?array $expirationWarningInterval = null,
     ) {}
 }

--- a/packages/php-sdk/tests/Unit/TurboSignScheduleTest.php
+++ b/packages/php-sdk/tests/Unit/TurboSignScheduleTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use TurboDocx\TurboSign;
+use TurboDocx\Types\Requests\SendSignatureRequest;
+use ReflectionMethod;
+
+/**
+ * TurboSign reminder + expiration schedule tests.
+ *
+ * Mirrors the js-sdk, py-sdk, go-sdk and ruby-sdk suites case-for-case, per the cross-SDK
+ * test-parity rule.
+ *
+ * These invoke the REAL private helper through reflection rather than re-implementing its logic,
+ * so a change to the shipped serializer breaks the test.
+ *
+ * Durations are JSON-encoded on both send paths: multipart/form-data cannot carry a nested value,
+ * and the API decodes a JSON-string duration on either content type, so one code path serves both.
+ * Request-body keys stay camelCase — the API is not snake_case-aware.
+ */
+final class TurboSignScheduleTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $scheduleArgs
+     * @return array<string, mixed>
+     */
+    private function applyOverrides(array $scheduleArgs): array
+    {
+        // Named-argument spread must come as one array — PHP forbids unpacking AFTER named args.
+        $request = new SendSignatureRequest(...array_merge(
+            ['recipients' => [], 'fields' => [], 'deliverableId' => 'deliv-1'],
+            $scheduleArgs
+        ));
+
+        $formData = [];
+        $method = new ReflectionMethod(TurboSign::class, 'applyScheduleOverrides');
+        $method->invokeArgs(null, [&$formData, $request]);
+
+        return $formData;
+    }
+
+    public function testSendsEveryScheduleField(): void
+    {
+        $formData = $this->applyOverrides([
+            'remindersEnabled' => true,
+            'reminderDelay' => ['value' => 3, 'unit' => 'days'],
+            'reminderInterval' => ['value' => 12, 'unit' => 'hours'],
+            'maxReminders' => 5,
+            'expirationEnabled' => true,
+            'expireAfter' => ['value' => 30, 'unit' => 'days'],
+            'expirationWarning' => ['value' => 3, 'unit' => 'days'],
+            'expirationWarningInterval' => ['value' => 1, 'unit' => 'days'],
+        ]);
+
+        $this->assertTrue($formData['remindersEnabled']);
+        $this->assertSame(5, $formData['maxReminders']);
+        $this->assertTrue($formData['expirationEnabled']);
+        $this->assertSame(['value' => 3, 'unit' => 'days'], json_decode($formData['reminderDelay'], true));
+        $this->assertSame(['value' => 12, 'unit' => 'hours'], json_decode($formData['reminderInterval'], true));
+        $this->assertSame(['value' => 30, 'unit' => 'days'], json_decode($formData['expireAfter'], true));
+        $this->assertSame(['value' => 3, 'unit' => 'days'], json_decode($formData['expirationWarning'], true));
+        $this->assertSame(['value' => 1, 'unit' => 'days'], json_decode($formData['expirationWarningInterval'], true));
+    }
+
+    public function testOmitsEveryScheduleKeyWhenUnset(): void
+    {
+        $formData = $this->applyOverrides([]);
+
+        foreach ([
+            'remindersEnabled',
+            'reminderDelay',
+            'reminderInterval',
+            'maxReminders',
+            'expirationEnabled',
+            'expireAfter',
+            'expirationWarning',
+            'expirationWarningInterval',
+        ] as $key) {
+            $this->assertArrayNotHasKey($key, $formData, "$key should be omitted so the org default applies");
+        }
+    }
+
+    /**
+     * `false` and `0` are meaningful values, not "unset" — a truthiness check would drop them and
+     * silently fall back to the org default, the opposite of what the caller asked for.
+     */
+    public function testSendsExplicitFalseRatherThanDroppingIt(): void
+    {
+        $formData = $this->applyOverrides([
+            'remindersEnabled' => false,
+            'expirationEnabled' => false,
+        ]);
+
+        $this->assertFalse($formData['remindersEnabled']);
+        $this->assertFalse($formData['expirationEnabled']);
+    }
+
+    public function testSendsZeroAndUnlimitedMaxReminders(): void
+    {
+        $this->assertSame(0, $this->applyOverrides(['maxReminders' => 0])['maxReminders']);
+        $this->assertSame(-1, $this->applyOverrides(['maxReminders' => -1])['maxReminders']);
+    }
+
+    /** Zero is legal for the warning offset alone, and means "never warn". */
+    public function testSendsZeroExpirationWarning(): void
+    {
+        $formData = $this->applyOverrides([
+            'expirationWarning' => ['value' => 0, 'unit' => 'hours'],
+        ]);
+
+        $this->assertSame(['value' => 0, 'unit' => 'hours'], json_decode($formData['expirationWarning'], true));
+    }
+
+    public function testSendReminderIsPubliclyExposed(): void
+    {
+        $this->assertTrue(
+            method_exists(TurboSign::class, 'sendReminder'),
+            'TurboSign::sendReminder must exist for cross-SDK parity'
+        );
+
+        $method = new ReflectionMethod(TurboSign::class, 'sendReminder');
+        $this->assertTrue($method->isPublic());
+        $this->assertTrue($method->isStatic());
+
+        $params = $method->getParameters();
+        $this->assertSame('documentId', $params[0]->getName());
+        // recipientIds is optional — omitting it reminds every eligible signer.
+        $this->assertSame('recipientIds', $params[1]->getName());
+        $this->assertTrue($params[1]->isOptional());
+    }
+}

--- a/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
@@ -79,6 +79,53 @@ class TurboSign:
             )
         return cls._client
 
+
+    @staticmethod
+    def _apply_schedule_overrides(
+        target: Dict[str, Any],
+        *,
+        reminders_enabled: Optional[bool] = None,
+        reminder_delay: Optional[Dict[str, Any]] = None,
+        reminder_interval: Optional[Dict[str, Any]] = None,
+        max_reminders: Optional[int] = None,
+        expiration_enabled: Optional[bool] = None,
+        expire_after: Optional[Dict[str, Any]] = None,
+        expiration_warning: Optional[Dict[str, Any]] = None,
+        expiration_warning_interval: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """
+        Copy per-document reminder/expiration overrides onto an outgoing request body.
+
+        Durations are JSON-encoded. multipart/form-data has no notion of a nested value, so a
+        ``{"value": n, "unit": "days"}`` dict cannot survive the file-upload path as an object.
+        The API decodes a JSON-string duration on both content types, so encoding uniformly keeps
+        one code path for the multipart and JSON branches -- the same treatment ``recipients`` and
+        ``fields`` already get.
+
+        Presence is tested with ``is not None``, never truthiness: ``False`` (feature off) and
+        ``0`` (no reminders / never warn) are meaningful values, and a truthiness check would drop
+        them and silently fall back to the organization's default.
+
+        Request-body keys stay camelCase -- the API is not snake_case-aware.
+        """
+        if reminders_enabled is not None:
+            target["remindersEnabled"] = reminders_enabled
+        if max_reminders is not None:
+            target["maxReminders"] = max_reminders
+        if expiration_enabled is not None:
+            target["expirationEnabled"] = expiration_enabled
+
+        durations = {
+            "reminderDelay": reminder_delay,
+            "reminderInterval": reminder_interval,
+            "expireAfter": expire_after,
+            "expirationWarning": expiration_warning,
+            "expirationWarningInterval": expiration_warning_interval,
+        }
+        for key, duration in durations.items():
+            if duration is not None:
+                target[key] = json.dumps(duration)
+
     @classmethod
     async def create_signature_review_link(
         cls,
@@ -94,7 +141,15 @@ class TurboSign:
         document_description: Optional[str] = None,
         sender_name: Optional[str] = None,
         sender_email: Optional[str] = None,
-        cc_emails: Optional[List[str]] = None
+        cc_emails: Optional[List[str]] = None,
+        reminders_enabled: Optional[bool] = None,
+        reminder_delay: Optional[Dict[str, Any]] = None,
+        reminder_interval: Optional[Dict[str, Any]] = None,
+        max_reminders: Optional[int] = None,
+        expiration_enabled: Optional[bool] = None,
+        expire_after: Optional[Dict[str, Any]] = None,
+        expiration_warning: Optional[Dict[str, Any]] = None,
+        expiration_warning_interval: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """
         Create signature review link without sending emails
@@ -155,6 +210,17 @@ class TurboSign:
 
             if cc_emails:
                 form_data["ccEmails"] = json.dumps(cc_emails)
+            TurboSign._apply_schedule_overrides(
+                form_data,
+                reminders_enabled=reminders_enabled,
+                reminder_delay=reminder_delay,
+                reminder_interval=reminder_interval,
+                max_reminders=max_reminders,
+                expiration_enabled=expiration_enabled,
+                expire_after=expire_after,
+                expiration_warning=expiration_warning,
+                expiration_warning_interval=expiration_warning_interval,
+            )
 
             return await client.upload_file(
                 "/turbosign/single/prepare-for-review",
@@ -183,6 +249,17 @@ class TurboSign:
 
             if cc_emails:
                 json_body["ccEmails"] = json.dumps(cc_emails)
+            TurboSign._apply_schedule_overrides(
+                json_body,
+                reminders_enabled=reminders_enabled,
+                reminder_delay=reminder_delay,
+                reminder_interval=reminder_interval,
+                max_reminders=max_reminders,
+                expiration_enabled=expiration_enabled,
+                expire_after=expire_after,
+                expiration_warning=expiration_warning,
+                expiration_warning_interval=expiration_warning_interval,
+            )
 
             # URL, deliverable, or template
             if file_link:
@@ -212,7 +289,15 @@ class TurboSign:
         document_description: Optional[str] = None,
         sender_name: Optional[str] = None,
         sender_email: Optional[str] = None,
-        cc_emails: Optional[List[str]] = None
+        cc_emails: Optional[List[str]] = None,
+        reminders_enabled: Optional[bool] = None,
+        reminder_delay: Optional[Dict[str, Any]] = None,
+        reminder_interval: Optional[Dict[str, Any]] = None,
+        max_reminders: Optional[int] = None,
+        expiration_enabled: Optional[bool] = None,
+        expire_after: Optional[Dict[str, Any]] = None,
+        expiration_warning: Optional[Dict[str, Any]] = None,
+        expiration_warning_interval: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """
         Send signature request and immediately send emails
@@ -272,6 +357,17 @@ class TurboSign:
 
             if cc_emails:
                 form_data["ccEmails"] = json.dumps(cc_emails)
+            TurboSign._apply_schedule_overrides(
+                form_data,
+                reminders_enabled=reminders_enabled,
+                reminder_delay=reminder_delay,
+                reminder_interval=reminder_interval,
+                max_reminders=max_reminders,
+                expiration_enabled=expiration_enabled,
+                expire_after=expire_after,
+                expiration_warning=expiration_warning,
+                expiration_warning_interval=expiration_warning_interval,
+            )
 
             return await client.upload_file(
                 "/turbosign/single/prepare-for-signing",
@@ -300,6 +396,17 @@ class TurboSign:
 
             if cc_emails:
                 json_body["ccEmails"] = json.dumps(cc_emails)
+            TurboSign._apply_schedule_overrides(
+                json_body,
+                reminders_enabled=reminders_enabled,
+                reminder_delay=reminder_delay,
+                reminder_interval=reminder_interval,
+                max_reminders=max_reminders,
+                expiration_enabled=expiration_enabled,
+                expire_after=expire_after,
+                expiration_warning=expiration_warning,
+                expiration_warning_interval=expiration_warning_interval,
+            )
 
             # URL, deliverable, or template
             if file_link:
@@ -398,6 +505,55 @@ class TurboSign:
         return await client.post(
             f"/turbosign/documents/{document_id}/void",
             data={"reason": reason}
+        )
+
+    @classmethod
+    async def send_reminder(
+        cls,
+        document_id: str,
+        recipient_ids: Optional[List[str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Send a reminder email to a document's outstanding signers
+
+        This is a standalone nudge, deliberately decoupled from the automatic reminder schedule:
+        it ignores the configured cadence, works even when reminders are disabled or the
+        per-signer cap is already spent, and does not consume that cap.
+
+        Only signers at the CURRENT signing order are emailed. A recipient at a later order (or
+        one who has already signed) is reported back as skipped rather than silently dropped, so
+        the caller can tell that nobody was emailed.
+
+        Args:
+            document_id: ID of the document
+            recipient_ids: Optional subset to remind. Omit to remind every eligible signer.
+                When supplied, the request is all-or-nothing: if any id is not a current-order
+                pending signer the API rejects the whole call and sends nothing.
+
+        Returns:
+            Dict with:
+                - results: One entry per recipient considered, each with recipientId, status
+                  (e.g. "sent", "skipped_wrong_order"), and optionally reminderCount and phase
+
+        Example:
+            >>> result = await TurboSign.send_reminder("doc-123")
+            >>> for entry in result["results"]:
+            ...     print(entry["recipientId"], entry["status"])
+            >>> # Nudge one specific signer
+            >>> await TurboSign.send_reminder("doc-123", ["rec-1"])
+        """
+        client = cls._get_client()
+
+        # Only include the filter when it actually names someone. The API requires at least one
+        # id when the key is present, so forwarding an empty list would guarantee a 400 -- an
+        # empty list is far more likely to mean "no filter" than "remind nobody".
+        body: Dict[str, Any] = {}
+        if recipient_ids:
+            body["recipientIds"] = recipient_ids
+
+        return await client.post(
+            f"/turbosign/documents/{document_id}/send-reminder",
+            data=body
         )
 
     @classmethod

--- a/packages/py-sdk/tests/test_turbosign_schedule.py
+++ b/packages/py-sdk/tests/test_turbosign_schedule.py
@@ -1,0 +1,212 @@
+"""
+TurboSign reminder + expiration schedule tests (py-sdk).
+
+Mirrors the js-sdk suite case-for-case, per the cross-SDK test-parity rule.
+
+Durations are JSON-encoded on both send paths: multipart/form-data cannot carry a nested value,
+and the API decodes a JSON-string duration on either content type, so one code path serves both.
+Request-body keys stay camelCase — the API is not snake_case-aware.
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from turbodocx_sdk.modules.sign import TurboSign
+
+RECIPIENTS = [{"name": "John Doe", "email": "john@example.com", "signingOrder": 1}]
+FIELDS = [
+    {
+        "type": "signature",
+        "page": 1,
+        "x": 100,
+        "y": 500,
+        "width": 200,
+        "height": 50,
+        "recipientEmail": "john@example.com",
+    }
+]
+
+
+@pytest.fixture(autouse=True)
+def _configure():
+    TurboSign.configure(
+        api_key="test-key", org_id="org-1", sender_email="sender@company.com"
+    )
+    yield
+    TurboSign._client = None
+
+
+def _post_body(mock_post):
+    """The JSON body the SDK sent (this module passes it as the `data=` kwarg)."""
+    return mock_post.call_args.kwargs["data"]
+
+
+class TestScheduleOverrides:
+    @pytest.mark.asyncio
+    async def test_sends_every_schedule_field(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={"documentId": "doc-1"})
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS,
+                fields=FIELDS,
+                deliverable_id="deliv-1",
+                reminders_enabled=True,
+                reminder_delay={"value": 3, "unit": "days"},
+                reminder_interval={"value": 12, "unit": "hours"},
+                max_reminders=5,
+                expiration_enabled=True,
+                expire_after={"value": 30, "unit": "days"},
+                expiration_warning={"value": 3, "unit": "days"},
+                expiration_warning_interval={"value": 1, "unit": "days"},
+            )
+
+            body = _post_body(client.post)
+            assert body["remindersEnabled"] is True
+            assert body["maxReminders"] == 5
+            assert body["expirationEnabled"] is True
+            assert json.loads(body["reminderDelay"]) == {"value": 3, "unit": "days"}
+            assert json.loads(body["reminderInterval"]) == {"value": 12, "unit": "hours"}
+            assert json.loads(body["expireAfter"]) == {"value": 30, "unit": "days"}
+            assert json.loads(body["expirationWarning"]) == {"value": 3, "unit": "days"}
+            assert json.loads(body["expirationWarningInterval"]) == {"value": 1, "unit": "days"}
+
+    @pytest.mark.asyncio
+    async def test_omits_every_schedule_key_when_unset(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={"documentId": "doc-1"})
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS, fields=FIELDS, deliverable_id="deliv-1"
+            )
+
+            body = _post_body(client.post)
+            for key in (
+                "remindersEnabled",
+                "reminderDelay",
+                "reminderInterval",
+                "maxReminders",
+                "expirationEnabled",
+                "expireAfter",
+                "expirationWarning",
+                "expirationWarningInterval",
+            ):
+                assert key not in body
+
+    # False and 0 are meaningful values, not "unset" — a truthiness check would drop them and
+    # silently fall back to the org default, the opposite of what the caller asked for.
+    @pytest.mark.asyncio
+    async def test_sends_false_rather_than_dropping_it(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={})
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS,
+                fields=FIELDS,
+                deliverable_id="d",
+                reminders_enabled=False,
+                expiration_enabled=False,
+            )
+
+            body = _post_body(client.post)
+            assert body["remindersEnabled"] is False
+            assert body["expirationEnabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_sends_zero_and_negative_max_reminders(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={})
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS, fields=FIELDS, deliverable_id="d", max_reminders=0
+            )
+            assert _post_body(client.post)["maxReminders"] == 0
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS, fields=FIELDS, deliverable_id="d", max_reminders=-1
+            )
+            assert _post_body(client.post)["maxReminders"] == -1
+
+    # Zero is legal for the warning offset alone, and means "never warn".
+    @pytest.mark.asyncio
+    async def test_sends_zero_expiration_warning(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={})
+
+            await TurboSign.send_signature(
+                recipients=RECIPIENTS,
+                fields=FIELDS,
+                deliverable_id="d",
+                expiration_warning={"value": 0, "unit": "hours"},
+            )
+
+            assert json.loads(_post_body(client.post)["expirationWarning"]) == {
+                "value": 0,
+                "unit": "hours",
+            }
+
+
+class TestSendReminder:
+    @pytest.mark.asyncio
+    async def test_posts_to_the_send_reminder_endpoint(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={"results": []})
+
+            await TurboSign.send_reminder("doc-123")
+
+            client.post.assert_called_once_with(
+                "/turbosign/documents/doc-123/send-reminder", data={}
+            )
+
+    @pytest.mark.asyncio
+    async def test_passes_named_recipient_ids(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={"results": []})
+
+            await TurboSign.send_reminder("doc-123", ["r-1", "r-2"])
+
+            client.post.assert_called_once_with(
+                "/turbosign/documents/doc-123/send-reminder",
+                data={"recipientIds": ["r-1", "r-2"]},
+            )
+
+    # An empty list is a caller mistake the API would 400 on (min 1 when the key is present).
+    # Treat it as "no filter" rather than forwarding a request that cannot succeed.
+    @pytest.mark.asyncio
+    async def test_empty_recipient_list_is_treated_as_unfiltered(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(return_value={"results": []})
+
+            await TurboSign.send_reminder("doc-123", [])
+
+            assert "recipientIds" not in _post_body(client.post)
+
+    @pytest.mark.asyncio
+    async def test_returns_per_recipient_results(self):
+        with patch.object(TurboSign, "_get_client") as get_client:
+            client = get_client.return_value
+            client.post = AsyncMock(
+                return_value={
+                    "results": [
+                        {"recipientId": "r-1", "status": "sent", "reminderCount": 2, "phase": "reminder"},
+                        {"recipientId": "r-2", "status": "skipped_wrong_order"},
+                    ]
+                }
+            )
+
+            result = await TurboSign.send_reminder("doc-123")
+
+            assert len(result["results"]) == 2
+            assert result["results"][0]["status"] == "sent"
+            # A later-order signer is reported, not silently dropped.
+            assert result["results"][1]["status"] == "skipped_wrong_order"

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
@@ -124,6 +124,37 @@ module TurboDocxSdk
         client.post("/turbosign/documents/#{document_id}/resend-email", { "recipientIds" => recipient_ids })
       end
 
+      # Send a reminder email to a document's outstanding signers.
+      #
+      # This is a standalone nudge, deliberately decoupled from the automatic reminder schedule:
+      # it ignores the configured cadence, works even when reminders are disabled or the
+      # per-signer cap is already spent, and does not consume that cap.
+      #
+      # Only signers at the CURRENT signing order are emailed. A recipient at a later order (or
+      # one who has already signed) is reported back as skipped rather than silently dropped, so
+      # the caller can tell that nobody was emailed.
+      #
+      # @param document_id [String]
+      # @param recipient_ids [Array<String>, nil] optional subset to remind. Omit to remind every
+      #   eligible signer. When supplied the request is all-or-nothing: if any id is not a
+      #   current-order pending signer the API rejects the whole call and sends nothing.
+      # @return [Hash] :results, one entry per recipient considered, each with recipientId and
+      #   status (e.g. "sent", "skipped_wrong_order")
+      # @raise [NotFoundError] if the document does not exist
+      # @raise [AuthenticationError] on invalid credentials
+      # @raise [NetworkError] on connection failure
+      def send_reminder(document_id, recipient_ids = nil)
+        client = get_client
+
+        # Only include the filter when it actually names someone. The API requires at least one id
+        # when the key is present, so forwarding an empty array would guarantee a 400 -- an empty
+        # list is far more likely to mean "no filter" than "remind nobody".
+        body = {}
+        body["recipientIds"] = recipient_ids if recipient_ids && !recipient_ids.empty?
+
+        client.post("/turbosign/documents/#{document_id}/send-reminder", body)
+      end
+
       # Get the audit trail for a document.
       #
       # @param document_id [String]
@@ -205,7 +236,38 @@ module TurboDocxSdk
           form_data["ccEmails"] = JSON.generate(cc_array)
         end
 
+        apply_schedule_overrides(form_data, request)
+
         form_data
+      end
+
+      # Copy per-document reminder/expiration overrides onto an outgoing request body.
+      #
+      # Durations are JSON-encoded. multipart/form-data has no notion of a nested value, so a
+      # { value:, unit: } hash cannot survive the file-upload path as an object. The API decodes a
+      # JSON-string duration on both content types, so encoding uniformly keeps one code path for
+      # the multipart and JSON branches -- the same treatment recipients and fields already get.
+      #
+      # Presence is tested with nil?, never truthiness: false (feature off) and 0 (no reminders /
+      # never warn) are meaningful values, and Ruby treats 0 as truthy but false as falsey, so a
+      # truthiness check would silently drop an explicit "off" and fall back to the org default.
+      #
+      # Request-body keys stay camelCase -- the API is not snake_case-aware.
+      def apply_schedule_overrides(form_data, request)
+        scalar_keys = %w[remindersEnabled maxReminders expirationEnabled]
+        scalar_keys.each do |key|
+          value = request[key.to_sym]
+          value = request[key] if value.nil?
+          form_data[key] = value unless value.nil?
+        end
+
+        duration_keys = %w[reminderDelay reminderInterval expireAfter expirationWarning
+                           expirationWarningInterval]
+        duration_keys.each do |key|
+          duration = request[key.to_sym]
+          duration = request[key] if duration.nil?
+          form_data[key] = JSON.generate(duration) unless duration.nil?
+        end
       end
     end
   end

--- a/packages/ruby-sdk/spec/turbo_sign_schedule_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_sign_schedule_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# TurboSign reminder + expiration schedule specs.
+#
+# Mirrors the js-sdk and py-sdk suites case-for-case, per the cross-SDK test-parity rule.
+#
+# Durations are JSON-encoded on both send paths: multipart/form-data cannot carry a nested value,
+# and the API decodes a JSON-string duration on either content type, so one code path serves both.
+# Request-body keys stay camelCase — the API is not snake_case-aware.
+RSpec.describe TurboDocxSdk::TurboSign do
+  let(:mock_client) { instance_double(TurboDocxSdk::HttpClient) }
+  let(:recipients) { [{ "name" => "John Doe", "email" => "john@example.com", "signingOrder" => 1 }] }
+  let(:fields) do
+    [{ "type" => "signature", "page" => 1, "x" => 100, "y" => 500,
+       "width" => 200, "height" => 50, "recipientEmail" => "john@example.com" }]
+  end
+
+  before do
+    described_class.instance_variable_set(:@client, nil)
+    allow(TurboDocxSdk::HttpClient).to receive(:new).and_return(mock_client)
+    allow(mock_client).to receive(:sender_config).and_return({
+      "senderEmail" => "test@company.com",
+      "senderName" => "Test Company"
+    })
+    described_class.configure(
+      api_key: "test-api-key",
+      org_id: "test-org-id",
+      sender_email: "test@company.com"
+    )
+  end
+
+  describe "schedule overrides" do
+    it "sends every schedule field the API accepts" do
+      allow(mock_client).to receive(:post).and_return({})
+
+      described_class.send_signature(
+        deliverableId: "deliv-1",
+        recipients: recipients,
+        fields: fields,
+        remindersEnabled: true,
+        reminderDelay: { "value" => 3, "unit" => "days" },
+        reminderInterval: { "value" => 12, "unit" => "hours" },
+        maxReminders: 5,
+        expirationEnabled: true,
+        expireAfter: { "value" => 30, "unit" => "days" },
+        expirationWarning: { "value" => 3, "unit" => "days" },
+        expirationWarningInterval: { "value" => 1, "unit" => "days" }
+      )
+
+      expect(mock_client).to have_received(:post) do |_path, body|
+        expect(body["remindersEnabled"]).to be(true)
+        expect(body["maxReminders"]).to eq(5)
+        expect(body["expirationEnabled"]).to be(true)
+        expect(JSON.parse(body["reminderDelay"])).to eq({ "value" => 3, "unit" => "days" })
+        expect(JSON.parse(body["reminderInterval"])).to eq({ "value" => 12, "unit" => "hours" })
+        expect(JSON.parse(body["expireAfter"])).to eq({ "value" => 30, "unit" => "days" })
+        expect(JSON.parse(body["expirationWarning"])).to eq({ "value" => 3, "unit" => "days" })
+        expect(JSON.parse(body["expirationWarningInterval"])).to eq({ "value" => 1, "unit" => "days" })
+      end
+    end
+
+    it "omits every schedule key when the caller sets none, so the org defaults apply" do
+      allow(mock_client).to receive(:post).and_return({})
+
+      described_class.send_signature(deliverableId: "deliv-1", recipients: recipients, fields: fields)
+
+      expect(mock_client).to have_received(:post) do |_path, body|
+        %w[remindersEnabled reminderDelay reminderInterval maxReminders expirationEnabled
+           expireAfter expirationWarning expirationWarningInterval].each do |key|
+          expect(body).not_to have_key(key)
+        end
+      end
+    end
+
+    # `false` is falsey in Ruby, so a truthiness check would drop an explicit "off" and silently
+    # fall back to the org default — the opposite of what the caller asked for.
+    it "sends remindersEnabled:false rather than dropping it" do
+      allow(mock_client).to receive(:post).and_return({})
+
+      described_class.send_signature(
+        deliverableId: "d", recipients: recipients, fields: fields,
+        remindersEnabled: false, expirationEnabled: false
+      )
+
+      expect(mock_client).to have_received(:post) do |_path, body|
+        expect(body["remindersEnabled"]).to be(false)
+        expect(body["expirationEnabled"]).to be(false)
+      end
+    end
+
+    it "sends maxReminders:0 (no reminders) and -1 (unlimited) rather than dropping them" do
+      allow(mock_client).to receive(:post).and_return({})
+
+      described_class.send_signature(
+        deliverableId: "d", recipients: recipients, fields: fields, maxReminders: 0
+      )
+      described_class.send_signature(
+        deliverableId: "d", recipients: recipients, fields: fields, maxReminders: -1
+      )
+
+      bodies = []
+      expect(mock_client).to have_received(:post).twice { |_path, body| bodies << body }
+      expect(bodies[0]["maxReminders"]).to eq(0)
+      expect(bodies[1]["maxReminders"]).to eq(-1)
+    end
+
+    # Zero is legal for the warning offset alone, and means "never warn".
+    it "sends a zero expirationWarning, which means no warning emails" do
+      allow(mock_client).to receive(:post).and_return({})
+
+      described_class.send_signature(
+        deliverableId: "d", recipients: recipients, fields: fields,
+        expirationWarning: { "value" => 0, "unit" => "hours" }
+      )
+
+      expect(mock_client).to have_received(:post) do |_path, body|
+        expect(JSON.parse(body["expirationWarning"])).to eq({ "value" => 0, "unit" => "hours" })
+      end
+    end
+
+    it "carries the schedule through the multipart file-upload path" do
+      allow(mock_client).to receive(:upload_file).and_return({})
+
+      described_class.create_signature_review_link(
+        file: "%PDF-1.4",
+        recipients: recipients,
+        fields: fields,
+        remindersEnabled: true,
+        reminderDelay: { "value" => 2, "unit" => "days" }
+      )
+
+      expect(mock_client).to have_received(:upload_file) do |_path, _file, opts|
+        expect(opts[:additional_data]["remindersEnabled"]).to be(true)
+        expect(JSON.parse(opts[:additional_data]["reminderDelay"])).to eq({ "value" => 2, "unit" => "days" })
+      end
+    end
+  end
+
+  describe ".send_reminder" do
+    it "posts to the send-reminder endpoint for the given document" do
+      allow(mock_client).to receive(:post).and_return({ "results" => [] })
+
+      described_class.send_reminder("doc-123")
+
+      expect(mock_client).to have_received(:post)
+        .with("/turbosign/documents/doc-123/send-reminder", {})
+    end
+
+    it "passes named recipient ids through when supplied" do
+      allow(mock_client).to receive(:post).and_return({ "results" => [] })
+
+      described_class.send_reminder("doc-123", %w[r-1 r-2])
+
+      expect(mock_client).to have_received(:post)
+        .with("/turbosign/documents/doc-123/send-reminder", { "recipientIds" => %w[r-1 r-2] })
+    end
+
+    # An empty array is a caller mistake the API would 400 on (min 1 when the key is present).
+    # Treat it as "no filter" rather than forwarding a request that cannot succeed.
+    it "treats an empty recipient list as unfiltered" do
+      allow(mock_client).to receive(:post).and_return({ "results" => [] })
+
+      described_class.send_reminder("doc-123", [])
+
+      expect(mock_client).to have_received(:post)
+        .with("/turbosign/documents/doc-123/send-reminder", {})
+    end
+
+    it "returns the per-recipient results the API reports" do
+      allow(mock_client).to receive(:post).and_return({
+        "results" => [
+          { "recipientId" => "r-1", "status" => "sent", "reminderCount" => 2, "phase" => "reminder" },
+          { "recipientId" => "r-2", "status" => "skipped_wrong_order" }
+        ]
+      })
+
+      result = described_class.send_reminder("doc-123")
+
+      expect(result["results"].length).to eq(2)
+      expect(result["results"][0]["status"]).to eq("sent")
+      # A later-order signer is reported, not silently dropped.
+      expect(result["results"][1]["status"]).to eq("skipped_wrong_order")
+    end
+  end
+end

--- a/packages/ruby-sdk/spec/turbo_sign_schedule_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_sign_schedule_spec.rb
@@ -91,7 +91,13 @@ RSpec.describe TurboDocxSdk::TurboSign do
     end
 
     it "sends maxReminders:0 (no reminders) and -1 (unlimited) rather than dropping them" do
-      allow(mock_client).to receive(:post).and_return({})
+      # Capture on the stub itself — `have_received(...).twice { }` does not yield the args, so
+      # the block never populates anything.
+      bodies = []
+      allow(mock_client).to receive(:post) do |_path, body|
+        bodies << body
+        {}
+      end
 
       described_class.send_signature(
         deliverableId: "d", recipients: recipients, fields: fields, maxReminders: 0
@@ -100,8 +106,7 @@ RSpec.describe TurboDocxSdk::TurboSign do
         deliverableId: "d", recipients: recipients, fields: fields, maxReminders: -1
       )
 
-      bodies = []
-      expect(mock_client).to have_received(:post).twice { |_path, body| bodies << body }
+      expect(bodies.length).to eq(2)
       expect(bodies[0]["maxReminders"]).to eq(0)
       expect(bodies[1]["maxReminders"]).to eq(-1)
     end


### PR DESCRIPTION
Wraps the newly-released TurboSign reminder and expiration surface. Implemented in all six languages to keep cross-SDK parity.

## What's new

**`sendReminder(documentId, recipientIds?)`** — a standalone nudge, deliberately decoupled from the automatic reminder schedule: it ignores the configured cadence, works even when reminders are disabled or the per-signer cap is spent, and does not consume that cap. Only signers at the current signing order are emailed; a later-order or already-signed recipient comes back as a `skipped_*` result rather than being dropped, so the caller can tell nobody was emailed.

**Per-document schedule overrides** on both send paths — the eight reminder/expiration fields. Omitted fields inherit the organization's defaults, and both features are off by default, so **an existing caller's behaviour is unchanged**.

**`expiresAt`** on the status response, plus the new terminal `expired` status.

## Two contract details worth reviewing

Both are locked by tests in every language:

1. **Durations are JSON-encoded on BOTH send paths.** A duration is `{value, unit}`, but `multipart/form-data` has no notion of a nested value, so the object cannot survive the file-upload path. The API decodes a JSON-string duration on either content type, so encoding uniformly keeps one code path for the multipart and JSON branches — the same treatment `recipients` and `fields` already get.

2. **Presence is null-checked, never truthiness.** `false` (feature off), `0` (no reminders / never warn) and `-1` (unlimited) are all meaningful values; a truthiness check would drop them and silently fall back to the org default — the opposite of what the caller asked for. Go uses pointer fields and Java boxed types specifically so "unset" stays distinguishable from a deliberate zero value.

## Verification

| SDK | Result |
|---|---|
| js | 320 tests, build clean |
| py | 328 tests |
| php | 347 tests + phpstan clean |
| go | all green, `go vet` clean |
| java | all green |
| ruby | specs written to the same shape, **not run locally** (no Ruby runtime on this machine) — CI covers them |

Tests mirror the same cases in every language per the test-parity rule. `cross-sdk-parity.md` records the new operation and both contract rules.