### PR TITLE
feat: add TurboSign getRecipients across all six SDKs

### DIFF
--- a/.claude/rules/cross-sdk-parity.md
+++ b/.claude/rules/cross-sdk-parity.md
@@ -10,6 +10,7 @@ All SDKs must implement the same operations. When adding a feature to one SDK, i
 | createSignatureReviewLink | `createSignatureReviewLink()` | `create_signature_review_link()` | `CreateSignatureReviewLink()` | `createSignatureReviewLink()` | `createSignatureReviewLink()` | `create_signature_review_link()` |
 | sendSignature | `sendSignature()` | `send_signature()` | `SendSignature()` | `sendSignature()` | `sendSignature()` | `send_signature()` |
 | getStatus | `getStatus()` | `get_status()` | `GetStatus()` | `getStatus()` | `getStatus()` | `get_status()` |
+| getRecipients | `getRecipients()` | `get_recipients()` | `GetRecipients()` | `getRecipients()` | `getRecipients()` | `get_recipients()` |
 | download | `download()` | `download()` | `Download()` | `download()` | `download()` | `download()` |
 | void | `void()` | `void_document()` | `VoidDocument()` | `void()` | `voidDocument()` | `void_document()` |
 | resend | `resend()` | `resend_email()` | `ResendEmail()` | `resend()` | `resendEmail()` | `resend_email()` |
@@ -23,6 +24,17 @@ the sanctioned idiomatic form, not a parity gap.
 **PHP void note:** PHP ships `TurboSign::void()` (not `voidDocument()`) — `void` is a valid PHP
 method name and the method is published; renaming would break users. The table above reflects the
 shipped name.
+
+**getRecipients return-shape note:** JS, Go, PHP and Java return a typed model
+(`DocumentRecipientsResponse`); Python and Ruby return the raw `Dict`/`Hash`, matching how
+those two already handle every other TurboSign read (`get_status`, `get_audit_trail`). That is
+the sanctioned idiomatic split, not a parity gap.
+
+**Recipient status has three values only** — `pending`, `viewed`, `completed`. There is no
+per-recipient declined/expired/voided state, so on a voided or expired document every unsigned
+recipient still reads `pending`. Every SDK therefore returns the document-level status
+alongside the roster, and callers must overlay it to tell "still waiting" from "this document
+is dead". Keep that caveat in each language's docstring.
 
 ## Required TurboPartner Operations
 

--- a/.claude/rules/cross-sdk-parity.md
+++ b/.claude/rules/cross-sdk-parity.md
@@ -46,6 +46,16 @@ and that distinction, in every language's docs — dropping `status` or aliasing
 signer. It counts the signature request, resends, reminders, expiry warnings and terminal
 notices, and deliberately excludes CC notifications (a CC address is not a signer).
 
+**Two `delivery` fields do not mean what their names suggest, and every language's docs must
+say so.** `reminderCount` counts **automatic (scheduled) reminders only** — it is the counter
+`maxReminders` caps; a manual "remind now" deliberately does not increment it (a standalone
+nudge must not consume the cap budget) even though it does land in `totalSent`, so it can read
+0 while reminder emails have genuinely been sent. `lastRemindedAt` is **when the reminder
+cadence clock was last reset**, not when a reminder was sent: the initial signature-request
+send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it,
+so a freshly-sent document normally reads a non-null `lastRemindedAt` alongside
+`reminderCount` of 0. Only `warningCount` / `lastWarningAt` mean exactly what they say.
+
 ## Required TurboPartner Operations
 
 - Organization CRUD: create, list, getDetails, update, delete

--- a/.claude/rules/cross-sdk-parity.md
+++ b/.claude/rules/cross-sdk-parity.md
@@ -30,11 +30,21 @@ shipped name.
 those two already handle every other TurboSign read (`get_status`, `get_audit_trail`). That is
 the sanctioned idiomatic split, not a parity gap.
 
-**Recipient status has three values only** — `pending`, `viewed`, `completed`. There is no
-per-recipient declined/expired/voided state, so on a voided or expired document every unsigned
-recipient still reads `pending`. Every SDK therefore returns the document-level status
-alongside the roster, and callers must overlay it to tell "still waiting" from "this document
-is dead". Keep that caveat in each language's docstring.
+**`getRecipients` returns two status fields per recipient, and they differ on purpose.**
+`status` is the raw database value and has three values only — `pending`, `viewed`,
+`completed`. There is no per-recipient declined/expired/voided state in the schema, so on a
+voided or expired document an unsigned signer still reads `pending` there. `effectiveStatus`
+is the backend's overlay — `pending`, `viewed`, `completed`, `voided`, `expired` — and is what
+UIs should display. A completed signature is never revoked, so someone who signed before the
+document was voided still reads `completed`. `summary` counts by `effectiveStatus` and carries
+`waitingOn` (pending + viewed), which is zero once the document is terminal. Keep both fields,
+and that distinction, in every language's docs — dropping `status` or aliasing it to
+`effectiveStatus` breaks callers who need the raw value.
+
+**Each recipient also carries a `delivery` block** — `firstSentOn`, `lastSentOn`, `totalSent`,
+`reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt` — the email history for that
+signer. It counts the signature request, resends, reminders, expiry warnings and terminal
+notices, and deliberately excludes CC notifications (a CC address is not a signer).
 
 ## Required TurboPartner Operations
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ const { documentId, recipients } = await TurboSign.sendSignature({
   ]
 });
 
-console.log(`✅ Document sent! Sign URL: ${recipients[0].signUrl}`);
+// The created recipients come back on the send result (id, name, email).
+// Signing links are emailed to them — they are not returned here.
+console.log(`✅ Document sent to ${recipients[0].name} <${recipients[0].email}>`);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ import { TurboSign } from '@turbodocx/sdk';
 TurboSign.configure({ apiKey: process.env.TURBODOCX_API_KEY });
 
 // Send for signature
-const { documentId, recipients } = await TurboSign.prepareForSigningSingle({
+const { documentId, recipients } = await TurboSign.sendSignature({
   fileLink: 'https://example.com/contract.pdf',
   recipients: [
     { name: 'John Doe', email: 'john@example.com', order: 1 }
@@ -213,12 +213,14 @@ Send documents for legally-binding eSignatures with full audit trails.
 
 | Method | Description |
 |:-------|:------------|
-| `prepareForReview()` | Upload document for preview without sending emails |
-| `prepareForSigningSingle()` | Upload and immediately send signature requests |
-| `getStatus()` | Check document and recipient signing status |
+| `createSignatureReviewLink()` | Upload document for preview without sending emails |
+| `sendSignature()` | Upload and immediately send signature requests |
+| `getStatus()` | Check the document-level status |
+| `getRecipients()` | Per-signer status, email history, and who sent the document |
 | `download()` | Download the completed signed document |
 | `void()` | Cancel/void a signature request |
 | `resend()` | Resend signature request emails |
+| `getAuditTrail()` | Get the complete audit trail |
 
 ### TurboDocx — Document Generation *(Coming Soon)*
 
@@ -233,7 +235,7 @@ Generate documents from templates with dynamic data.
 Specify exact positions for signature fields using page coordinates:
 
 ```typescript
-const result = await TurboSign.prepareForSigningSingle({
+const result = await TurboSign.sendSignature({
   fileLink: 'https://example.com/contract.pdf',
   recipients: [
     { name: 'Alice Smith', email: 'alice@example.com', order: 1 },
@@ -263,7 +265,7 @@ const result = await TurboSign.prepareForSigningSingle({
 Use text anchors in your PDF to automatically position signature fields:
 
 ```typescript
-const result = await TurboSign.prepareForSigningSingle({
+const result = await TurboSign.sendSignature({
   fileLink: 'https://example.com/contract-with-placeholders.pdf',
   recipients: [
     { name: 'Alice Smith', email: 'alice@example.com', order: 1 },
@@ -293,7 +295,7 @@ import { TurboSign } from '@turbodocx/sdk';
 TurboSign.configure({ apiKey: process.env.TURBODOCX_API_KEY });
 
 // 1. Send document for signature
-const { documentId } = await TurboSign.prepareForSigningSingle({
+const { documentId } = await TurboSign.sendSignature({
   fileLink: 'https://example.com/contract.pdf',
   recipients: [
     { name: 'Alice', email: 'alice@example.com', order: 1 },
@@ -309,10 +311,15 @@ console.log(`Document ID: ${documentId}`);
 
 // 2. Check status
 const status = await TurboSign.getStatus(documentId);
-console.log(`Status: ${status.status}`);  // 'pending', 'completed', 'voided'
+console.log(`Status: ${status.status}`);  // 'under_review', 'completed', 'voided', ...
 
-for (const recipient of status.recipients) {
-  console.log(`  ${recipient.name}: ${recipient.status}`);
+// getStatus returns the document-level status only. For per-signer detail:
+const { recipients, summary } = await TurboSign.getRecipients(documentId);
+console.log(`${summary.completed}/${summary.total} signed, waiting on ${summary.waitingOn}`);
+
+for (const recipient of recipients) {
+  // 'pending' | 'viewed' | 'completed' | 'voided' | 'expired'
+  console.log(`  ${recipient.name}: ${recipient.effectiveStatus}`);
 }
 
 // 3. Download when complete

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -314,6 +314,15 @@ the document is terminal.
 request, resends, reminders, expiry warnings and terminal notices. CC notifications are
 excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `ReminderCount` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `TotalSent`. So it can read `0` while reminder emails have genuinely been sent. |
+| `LastRemindedAt` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `LastRemindedAt` alongside `ReminderCount` of `0`. |
+
+`WarningCount` and `LastWarningAt` are touched only by an expiry warning.
+
 #### `Download`
 
 Download the signed document.

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -262,17 +262,41 @@ fmt.Printf("Message: %s\n", result.Message)
 
 #### `GetStatus`
 
-Check the current status of a document.
+Check the document-level status. For per-recipient detail, use `GetRecipients`.
 
 ```go
 status, err := client.TurboSign.GetStatus(ctx, "doc-uuid-here")
 
-fmt.Printf("Status: %s\n", status.Status)  // "pending", "completed", "voided"
+fmt.Printf("Status: %s\n", status.Status)  // "under_review", "completed", "voided", ...
+```
 
-for _, r := range status.Recipients {
-    fmt.Printf("%s: %s\n", r.Name, r.Status)
+#### `GetRecipients`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```go
+result, err := client.TurboSign.GetRecipients(ctx, "doc-uuid-here")
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Printf("Sent by %s <%s>\n", result.Document.SentBy.Name, result.Document.SentBy.Email)
+fmt.Printf("%d of %d signed, %d not started\n",
+    result.Summary.Completed, result.Summary.Total, result.Summary.Pending)
+
+for _, r := range result.Recipients {
+    // "pending" | "viewed" | "completed"
+    fmt.Printf("%s <%s>: %s\n", r.Name, r.Email, r.Status)
+    if r.SignedOn != nil {
+        fmt.Printf("  signed %s\n", *r.SignedOn)
+    }
 }
 ```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `result.Document.Status` before treating
+> someone as "still to sign".
 
 #### `Download`
 
@@ -1164,6 +1188,7 @@ The `cmd/manual/main.go` program tests all SDK methods:
 - ✅ `CreateSignatureReviewLink()` - Document upload for review
 - ✅ `SendSignature()` - Send for signature
 - ✅ `GetStatus()` - Check document status
+- ✅ `GetRecipients()` - Per-recipient signing status (who signed, who is pending)
 - ✅ `Download()` - Download signed document
 - ✅ `VoidDocument()` - Cancel signature request
 - ✅ `ResendEmail()` - Resend signature emails

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -281,22 +281,38 @@ if err != nil {
 }
 
 fmt.Printf("Sent by %s <%s>\n", result.Document.SentBy.Name, result.Document.SentBy.Email)
-fmt.Printf("%d of %d signed, %d not started\n",
-    result.Summary.Completed, result.Summary.Total, result.Summary.Pending)
+fmt.Printf("%d of %d signed, still waiting on %d\n",
+    result.Summary.Completed, result.Summary.Total, result.Summary.WaitingOn)
 
 for _, r := range result.Recipients {
-    // "pending" | "viewed" | "completed"
-    fmt.Printf("%s <%s>: %s\n", r.Name, r.Email, r.Status)
+    // "pending" | "viewed" | "completed" | "voided" | "expired"
+    fmt.Printf("%s <%s>: %s\n", r.Name, r.Email, r.EffectiveStatus)
     if r.SignedOn != nil {
         fmt.Printf("  signed %s\n", *r.SignedOn)
     }
+    fmt.Printf("  emailed %dx\n", r.Delivery.TotalSent)
 }
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `result.Document.Status` before treating
-> someone as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `Status` | `pending`, `viewed`, `completed` | The raw database value |
+| `EffectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `Status`. `EffectiveStatus` layers the
+document's outcome on top — that's the one to show a user. A completed signature is never
+revoked: someone who signed before the document was voided still reads `completed`.
+
+`Summary` counts by effective status, and `WaitingOn` (pending + viewed) drops to zero once
+the document is terminal.
+
+**`Delivery`** is that recipient's email history — `FirstSentOn`, `LastSentOn`, `TotalSent`,
+`ReminderCount`, `LastRemindedAt`, `WarningCount`, `LastWarningAt`. It counts the signature
+request, resends, reminders, expiry warnings and terminal notices. CC notifications are
+excluded, since a CC address is not a signer.
 
 #### `Download`
 

--- a/packages/go-sdk/examples/turbosign_send_simple.go
+++ b/packages/go-sdk/examples/turbosign_send_simple.go
@@ -119,15 +119,17 @@ func main() {
 	fmt.Printf("Document ID: %s\n", result.DocumentID)
 	fmt.Printf("Message: %s\n", result.Message)
 
-	// To get sign URLs and recipient details, use GetStatus
-	status, err := client.TurboSign.GetStatus(ctx, result.DocumentID)
-	if err == nil && status.Recipients != nil {
-		fmt.Println("\nSign URLs:")
-		for _, recipient := range status.Recipients {
-			fmt.Printf("  %s: %s\n", recipient.Name, recipient.SignURL)
+	// Signing links are emailed to recipients — they are not returned by the API.
+	// GetRecipients reports who has signed and who you are still waiting on.
+	progress, err := client.TurboSign.GetRecipients(ctx, result.DocumentID)
+	if err == nil {
+		fmt.Printf("\n%d of %d signed, still waiting on %d\n",
+			progress.Summary.Completed, progress.Summary.Total, progress.Summary.WaitingOn)
+		for _, recipient := range progress.Recipients {
+			fmt.Printf("  %s <%s>: %s\n", recipient.Name, recipient.Email, recipient.EffectiveStatus)
 		}
 	} else {
-		fmt.Println("\nNote: Could not fetch recipient sign URLs")
+		fmt.Println("\nNote: Could not fetch recipient status")
 	}
 }
 

--- a/packages/go-sdk/turbosign.go
+++ b/packages/go-sdk/turbosign.go
@@ -188,11 +188,21 @@ type RecipientDelivery struct {
 	FirstSentOn *string `json:"firstSentOn"`
 	LastSentOn  *string `json:"lastSentOn"`
 	// TotalSent counts the request, resends, reminders, warnings and terminal notices.
-	TotalSent      int     `json:"totalSent"`
-	ReminderCount  int     `json:"reminderCount"`
+	TotalSent int `json:"totalSent"`
+	// ReminderCount counts AUTOMATIC (scheduled) reminders only — the counter maxReminders
+	// caps. A manual "remind now" does not increment it (it must not consume the cap
+	// budget), though it does land in TotalSent. So this can read 0 while reminder emails
+	// have genuinely been sent.
+	ReminderCount int `json:"reminderCount"`
+	// LastRemindedAt is when the reminder CADENCE CLOCK was last reset — not necessarily
+	// when a reminder was sent. Stamped by the initial signature-request send, each
+	// scheduled reminder, each manual "remind now", and each expiry warning. Only
+	// scheduled reminders bump ReminderCount, so a freshly-sent document normally shows a
+	// non-nil value here alongside ReminderCount 0. Nil means "never emailed on this cadence".
 	LastRemindedAt *string `json:"lastRemindedAt"`
-	WarningCount   int     `json:"warningCount"`
-	LastWarningAt  *string `json:"lastWarningAt"`
+	// WarningCount and LastWarningAt are touched only by an expiry warning.
+	WarningCount  int     `json:"warningCount"`
+	LastWarningAt *string `json:"lastWarningAt"`
 }
 
 // RecipientSignatureStatus is where a single recipient is in the signing process.

--- a/packages/go-sdk/turbosign.go
+++ b/packages/go-sdk/turbosign.go
@@ -171,10 +171,26 @@ type RecipientsDocument struct {
 	// declined/expired/voided state, so on a voided or expired document every unsigned
 	// recipient still reads "pending" — read this to tell "still waiting" apart from
 	// "this document is dead".
-	Status    string         `json:"status"`
-	CreatedOn string         `json:"createdOn"`
+	Status    string `json:"status"`
+	CreatedOn string `json:"createdOn"`
+	// SentOn is when the document was dispatched to recipients; nil while it is a draft.
+	SentOn    *string        `json:"sentOn"`
 	ExpiresAt *string        `json:"expiresAt"`
 	SentBy    DocumentSender `json:"sentBy"`
+}
+
+// RecipientDelivery is the email history for one recipient — every notification actually
+// sent to them. CC notifications are excluded; a CC address is not a signer.
+type RecipientDelivery struct {
+	// FirstSentOn is nil if this recipient has never been emailed.
+	FirstSentOn *string `json:"firstSentOn"`
+	LastSentOn  *string `json:"lastSentOn"`
+	// TotalSent counts the request, resends, reminders, warnings and terminal notices.
+	TotalSent      int     `json:"totalSent"`
+	ReminderCount  int     `json:"reminderCount"`
+	LastRemindedAt *string `json:"lastRemindedAt"`
+	WarningCount   int     `json:"warningCount"`
+	LastWarningAt  *string `json:"lastWarningAt"`
 }
 
 // RecipientSignatureStatus is where a single recipient is in the signing process.
@@ -182,20 +198,31 @@ type RecipientSignatureStatus struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Email string `json:"email"`
-	// Status is one of "pending", "viewed", "completed".
+	// Status is the raw database status — only ever "pending", "viewed" or "completed".
 	Status string `json:"status"`
+	// EffectiveStatus is Status with the document's terminal state layered on:
+	// "pending", "viewed", "completed", "voided" or "expired". Use this for display — a
+	// signer on a voided document reads "voided" here but still "pending" in Status.
+	// A completed signature is never revoked.
+	EffectiveStatus string `json:"effectiveStatus"`
 	// SignedOn is nil while the recipient is pending or has only viewed the document.
-	SignedOn     *string `json:"signedOn"`
-	SigningOrder int     `json:"signingOrder"`
+	SignedOn     *string           `json:"signedOn"`
+	SigningOrder int               `json:"signingOrder"`
+	Delivery     RecipientDelivery `json:"delivery"`
 }
 
-// RecipientStatusSummary rolls the roster up so callers can answer
+// RecipientStatusSummary rolls the roster up by effective status so callers can answer
 // "how many are we waiting on" without looping.
 type RecipientStatusSummary struct {
 	Total     int `json:"total"`
 	Pending   int `json:"pending"`
 	Viewed    int `json:"viewed"`
 	Completed int `json:"completed"`
+	// Voided and Expired count signers stranded by the document's terminal state.
+	Voided  int `json:"voided"`
+	Expired int `json:"expired"`
+	// WaitingOn is who can still act (pending + viewed). Zero once the document is terminal.
+	WaitingOn int `json:"waitingOn"`
 }
 
 // DocumentRecipientsResponse is the response from GetRecipients

--- a/packages/go-sdk/turbosign.go
+++ b/packages/go-sdk/turbosign.go
@@ -156,6 +156,55 @@ type DocumentStatusResponse struct {
 	Status string `json:"status"`
 }
 
+// DocumentSender is the identity that sent a document for signature.
+// Never the synthetic API service account.
+type DocumentSender struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// RecipientsDocument is the document the recipients belong to.
+type RecipientsDocument struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Status is the document-level status. There is no per-recipient
+	// declined/expired/voided state, so on a voided or expired document every unsigned
+	// recipient still reads "pending" — read this to tell "still waiting" apart from
+	// "this document is dead".
+	Status    string         `json:"status"`
+	CreatedOn string         `json:"createdOn"`
+	ExpiresAt *string        `json:"expiresAt"`
+	SentBy    DocumentSender `json:"sentBy"`
+}
+
+// RecipientSignatureStatus is where a single recipient is in the signing process.
+type RecipientSignatureStatus struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	// Status is one of "pending", "viewed", "completed".
+	Status string `json:"status"`
+	// SignedOn is nil while the recipient is pending or has only viewed the document.
+	SignedOn     *string `json:"signedOn"`
+	SigningOrder int     `json:"signingOrder"`
+}
+
+// RecipientStatusSummary rolls the roster up so callers can answer
+// "how many are we waiting on" without looping.
+type RecipientStatusSummary struct {
+	Total     int `json:"total"`
+	Pending   int `json:"pending"`
+	Viewed    int `json:"viewed"`
+	Completed int `json:"completed"`
+}
+
+// DocumentRecipientsResponse is the response from GetRecipients
+type DocumentRecipientsResponse struct {
+	Document   RecipientsDocument         `json:"document"`
+	Recipients []RecipientSignatureStatus `json:"recipients"`
+	Summary    RecipientStatusSummary     `json:"summary"`
+}
+
 // VoidDocumentResponse is the response from VoidDocument
 type VoidDocumentResponse struct {
 	ID         string `json:"id"`
@@ -370,6 +419,21 @@ func (c *TurboSignClient) GetStatus(ctx context.Context, documentID string) (*Do
 	var response DocumentStatusResponse
 
 	err := c.http.Get(ctx, "/turbosign/documents/"+documentID+"/status", &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// GetRecipients gets every recipient on a document with their signing status.
+//
+// Answers "who has signed and who are we still waiting on" in one call, and reports
+// who sent the document. Summary carries the pending/viewed/completed counts.
+func (c *TurboSignClient) GetRecipients(ctx context.Context, documentID string) (*DocumentRecipientsResponse, error) {
+	var response DocumentRecipientsResponse
+
+	err := c.http.Get(ctx, "/turbosign/documents/"+documentID+"/recipients", &response)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-sdk/turbosign.go
+++ b/packages/go-sdk/turbosign.go
@@ -167,10 +167,12 @@ type DocumentSender struct {
 type RecipientsDocument struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-	// Status is the document-level status. There is no per-recipient
-	// declined/expired/voided state, so on a voided or expired document every unsigned
-	// recipient still reads "pending" — read this to tell "still waiting" apart from
-	// "this document is dead".
+	// Status is the document-level status — the full SignatureDocumentStatus set
+	// ("draft", "under_review", "completed", "voided", "expired", …).
+	//
+	// For per-recipient display you do NOT need to overlay this yourself: each
+	// RecipientSignatureStatus already carries EffectiveStatus, which is the raw
+	// recipient status with this document-level outcome layered on.
 	Status    string `json:"status"`
 	CreatedOn string `json:"createdOn"`
 	// SentOn is when the document was dispatched to recipients; nil while it is a draft.

--- a/packages/go-sdk/turbosign_test.go
+++ b/packages/go-sdk/turbosign_test.go
@@ -312,6 +312,7 @@ func recipientsPayload() map[string]interface{} {
 				"name":      "Mutual NDA",
 				"status":    "under_review",
 				"createdOn": "2026-01-01T00:00:00.000Z",
+				"sentOn":    "2026-01-02T08:59:00.000Z",
 				"expiresAt": nil,
 				"sentBy": map[string]interface{}{
 					"name":  "Jane Sender",
@@ -320,24 +321,41 @@ func recipientsPayload() map[string]interface{} {
 			},
 			"recipients": []map[string]interface{}{
 				{
-					"id":           "rec-1",
-					"name":         "John Signer",
-					"email":        "john@example.com",
-					"status":       "completed",
-					"signedOn":     "2026-02-01T10:00:00.000Z",
-					"signingOrder": 1,
+					"id":              "rec-1",
+					"name":            "John Signer",
+					"email":           "john@example.com",
+					"status":          "completed",
+					"effectiveStatus": "completed",
+					"signedOn":        "2026-02-01T10:00:00.000Z",
+					"signingOrder":    1,
+					"delivery": map[string]interface{}{
+						"firstSentOn": "2026-01-02T09:00:00.000Z",
+						"lastSentOn":  "2026-01-09T09:00:00.000Z",
+						"totalSent":   3, "reminderCount": 1,
+						"lastRemindedAt": "2026-01-09T09:00:00.000Z",
+						"warningCount":   0, "lastWarningAt": nil,
+					},
 				},
 				{
-					"id":           "rec-2",
-					"name":         "Ada Signer",
-					"email":        "ada@example.com",
-					"status":       "pending",
-					"signedOn":     nil,
-					"signingOrder": 2,
+					"id":              "rec-2",
+					"name":            "Ada Signer",
+					"email":           "ada@example.com",
+					"status":          "pending",
+					"effectiveStatus": "pending",
+					"signedOn":        nil,
+					"signingOrder":    2,
+					"delivery": map[string]interface{}{
+						"firstSentOn": "2026-01-02T09:00:00.000Z",
+						"lastSentOn":  "2026-01-02T09:00:00.000Z",
+						"totalSent":   1, "reminderCount": 0,
+						"lastRemindedAt": nil,
+						"warningCount":   0, "lastWarningAt": nil,
+					},
 				},
 			},
 			"summary": map[string]interface{}{
 				"total": 2, "pending": 1, "viewed": 0, "completed": 1,
+				"voided": 0, "expired": 0, "waitingOn": 1,
 			},
 		},
 	}
@@ -369,6 +387,7 @@ func TestTurboSignClient_GetRecipients(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result.Recipients, 2)
 	assert.Equal(t, "completed", result.Recipients[0].Status)
+	assert.Equal(t, "completed", result.Recipients[0].EffectiveStatus)
 	assert.Equal(t, "john@example.com", result.Recipients[0].Email)
 	require.NotNil(t, result.Recipients[0].SignedOn)
 	assert.Equal(t, "2026-02-01T10:00:00.000Z", *result.Recipients[0].SignedOn)
@@ -396,10 +415,95 @@ func TestTurboSignClient_GetRecipientsSummaryAndSender(t *testing.T) {
 	assert.Equal(t, "jane@acme.com", result.Document.SentBy.Email)
 	// Document status distinguishes a voided/expired doc from one still waiting
 	assert.Equal(t, "under_review", result.Document.Status)
+	require.NotNil(t, result.Document.SentOn)
+	assert.Equal(t, "2026-01-02T08:59:00.000Z", *result.Document.SentOn)
 	assert.Equal(t, 2, result.Summary.Total)
 	assert.Equal(t, 1, result.Summary.Pending)
 	assert.Equal(t, 0, result.Summary.Viewed)
 	assert.Equal(t, 1, result.Summary.Completed)
+	assert.Equal(t, 0, result.Summary.Voided)
+	assert.Equal(t, 0, result.Summary.Expired)
+	assert.Equal(t, 1, result.Summary.WaitingOn)
+}
+
+func TestTurboSignClient_GetRecipientsDelivery(t *testing.T) {
+	server := newRecipientsServer(t)
+	defer server.Close()
+
+	client, _ := NewClientWithConfig(ClientConfig{
+		APIKey:      "test-api-key",
+		OrgID:       "test-org-id",
+		BaseURL:     server.URL,
+		SenderEmail: "test@example.com",
+	})
+
+	result, err := client.TurboSign.GetRecipients(context.Background(), "doc-123")
+
+	require.NoError(t, err)
+	chased := result.Recipients[0].Delivery
+	assert.Equal(t, 3, chased.TotalSent)
+	require.NotNil(t, chased.FirstSentOn)
+	assert.Equal(t, "2026-01-02T09:00:00.000Z", *chased.FirstSentOn)
+	require.NotNil(t, chased.LastSentOn)
+	assert.Equal(t, "2026-01-09T09:00:00.000Z", *chased.LastSentOn)
+	assert.Equal(t, 1, chased.ReminderCount)
+	// A recipient emailed once has no reminders
+	once := result.Recipients[1].Delivery
+	assert.Equal(t, 1, once.TotalSent)
+	assert.Nil(t, once.LastRemindedAt)
+}
+
+func TestTurboSignClient_GetRecipientsEffectiveStatusOnVoidedDocument(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": map[string]interface{}{
+				"document": map[string]interface{}{
+					"id": "doc-123", "name": "Mutual NDA", "status": "voided",
+					"createdOn": "2026-01-01T00:00:00.000Z", "sentOn": "2026-01-02T08:59:00.000Z",
+					"expiresAt": nil,
+					"sentBy":    map[string]interface{}{"name": "Jane Sender", "email": "jane@acme.com"},
+				},
+				"recipients": []map[string]interface{}{
+					{
+						"id": "rec-1", "name": "John Signer", "email": "john@example.com",
+						"status": "completed", "effectiveStatus": "completed",
+						"signedOn": "2026-02-01T10:00:00.000Z", "signingOrder": 1,
+						"delivery": map[string]interface{}{"totalSent": 1},
+					},
+					{
+						"id": "rec-2", "name": "Ada Signer", "email": "ada@example.com",
+						"status": "pending", "effectiveStatus": "voided",
+						"signedOn": nil, "signingOrder": 2,
+						"delivery": map[string]interface{}{"totalSent": 1},
+					},
+				},
+				"summary": map[string]interface{}{
+					"total": 2, "pending": 0, "viewed": 0, "completed": 1,
+					"voided": 1, "expired": 0, "waitingOn": 0,
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClientWithConfig(ClientConfig{
+		APIKey:      "test-api-key",
+		OrgID:       "test-org-id",
+		BaseURL:     server.URL,
+		SenderEmail: "test@example.com",
+	})
+
+	result, err := client.TurboSign.GetRecipients(context.Background(), "doc-123")
+
+	require.NoError(t, err)
+	// Someone who signed still signed — voiding the document does not undo it
+	assert.Equal(t, "completed", result.Recipients[0].EffectiveStatus)
+	// The unsigned signer is stranded, though the raw DB status is still "pending"
+	assert.Equal(t, "pending", result.Recipients[1].Status)
+	assert.Equal(t, "voided", result.Recipients[1].EffectiveStatus)
+	assert.Equal(t, 1, result.Summary.Voided)
+	assert.Equal(t, 0, result.Summary.WaitingOn)
 }
 
 func TestTurboSignClient_GetRecipientsNotFound(t *testing.T) {

--- a/packages/go-sdk/turbosign_test.go
+++ b/packages/go-sdk/turbosign_test.go
@@ -348,7 +348,8 @@ func recipientsPayload() map[string]interface{} {
 						"firstSentOn": "2026-01-02T09:00:00.000Z",
 						"lastSentOn":  "2026-01-02T09:00:00.000Z",
 						"totalSent":   1, "reminderCount": 0,
-						"lastRemindedAt": nil,
+						// Stamped by the initial send — NOT evidence of a reminder.
+						"lastRemindedAt": "2026-01-02T09:00:00.000Z",
 						"warningCount":   0, "lastWarningAt": nil,
 					},
 				},
@@ -447,10 +448,13 @@ func TestTurboSignClient_GetRecipientsDelivery(t *testing.T) {
 	require.NotNil(t, chased.LastSentOn)
 	assert.Equal(t, "2026-01-09T09:00:00.000Z", *chased.LastSentOn)
 	assert.Equal(t, 1, chased.ReminderCount)
-	// A recipient emailed once has no reminders
+	// Emailed once and never reminded: ReminderCount stays 0, but LastRemindedAt is NOT
+	// nil — the initial send stamps it as the reminder cadence clock.
 	once := result.Recipients[1].Delivery
 	assert.Equal(t, 1, once.TotalSent)
-	assert.Nil(t, once.LastRemindedAt)
+	assert.Equal(t, 0, once.ReminderCount)
+	assert.NotNil(t, once.LastRemindedAt)
+	assert.Equal(t, *once.FirstSentOn, *once.LastRemindedAt)
 }
 
 func TestTurboSignClient_GetRecipientsEffectiveStatusOnVoidedDocument(t *testing.T) {

--- a/packages/go-sdk/turbosign_test.go
+++ b/packages/go-sdk/turbosign_test.go
@@ -303,6 +303,130 @@ func TestTurboSignClient_GetStatus(t *testing.T) {
 	assert.Equal(t, "pending", result.Status)
 }
 
+// recipientsPayload is the wire shape the backend returns, envelope included.
+func recipientsPayload() map[string]interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"document": map[string]interface{}{
+				"id":        "doc-123",
+				"name":      "Mutual NDA",
+				"status":    "under_review",
+				"createdOn": "2026-01-01T00:00:00.000Z",
+				"expiresAt": nil,
+				"sentBy": map[string]interface{}{
+					"name":  "Jane Sender",
+					"email": "jane@acme.com",
+				},
+			},
+			"recipients": []map[string]interface{}{
+				{
+					"id":           "rec-1",
+					"name":         "John Signer",
+					"email":        "john@example.com",
+					"status":       "completed",
+					"signedOn":     "2026-02-01T10:00:00.000Z",
+					"signingOrder": 1,
+				},
+				{
+					"id":           "rec-2",
+					"name":         "Ada Signer",
+					"email":        "ada@example.com",
+					"status":       "pending",
+					"signedOn":     nil,
+					"signingOrder": 2,
+				},
+			},
+			"summary": map[string]interface{}{
+				"total": 2, "pending": 1, "viewed": 0, "completed": 1,
+			},
+		},
+	}
+}
+
+func newRecipientsServer(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/turbosign/documents/doc-123/recipients", r.URL.Path)
+		assert.Equal(t, "GET", r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(recipientsPayload())
+	}))
+}
+
+func TestTurboSignClient_GetRecipients(t *testing.T) {
+	server := newRecipientsServer(t)
+	defer server.Close()
+
+	client, _ := NewClientWithConfig(ClientConfig{
+		APIKey:      "test-api-key",
+		OrgID:       "test-org-id",
+		BaseURL:     server.URL,
+		SenderEmail: "test@example.com",
+	})
+
+	result, err := client.TurboSign.GetRecipients(context.Background(), "doc-123")
+
+	require.NoError(t, err)
+	require.Len(t, result.Recipients, 2)
+	assert.Equal(t, "completed", result.Recipients[0].Status)
+	assert.Equal(t, "john@example.com", result.Recipients[0].Email)
+	require.NotNil(t, result.Recipients[0].SignedOn)
+	assert.Equal(t, "2026-02-01T10:00:00.000Z", *result.Recipients[0].SignedOn)
+	assert.Equal(t, 1, result.Recipients[0].SigningOrder)
+	// A pending signer has no signedOn timestamp
+	assert.Equal(t, "pending", result.Recipients[1].Status)
+	assert.Nil(t, result.Recipients[1].SignedOn)
+}
+
+func TestTurboSignClient_GetRecipientsSummaryAndSender(t *testing.T) {
+	server := newRecipientsServer(t)
+	defer server.Close()
+
+	client, _ := NewClientWithConfig(ClientConfig{
+		APIKey:      "test-api-key",
+		OrgID:       "test-org-id",
+		BaseURL:     server.URL,
+		SenderEmail: "test@example.com",
+	})
+
+	result, err := client.TurboSign.GetRecipients(context.Background(), "doc-123")
+
+	require.NoError(t, err)
+	assert.Equal(t, "Jane Sender", result.Document.SentBy.Name)
+	assert.Equal(t, "jane@acme.com", result.Document.SentBy.Email)
+	// Document status distinguishes a voided/expired doc from one still waiting
+	assert.Equal(t, "under_review", result.Document.Status)
+	assert.Equal(t, 2, result.Summary.Total)
+	assert.Equal(t, 1, result.Summary.Pending)
+	assert.Equal(t, 0, result.Summary.Viewed)
+	assert.Equal(t, 1, result.Summary.Completed)
+}
+
+func TestTurboSignClient_GetRecipientsNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"message": "Document not found",
+			"code":    "DOCUMENT_NOT_FOUND",
+		})
+	}))
+	defer server.Close()
+
+	client, _ := NewClientWithConfig(ClientConfig{
+		APIKey:      "test-api-key",
+		OrgID:       "test-org-id",
+		BaseURL:     server.URL,
+		SenderEmail: "test@example.com",
+	})
+
+	_, err := client.TurboSign.GetRecipients(context.Background(), "missing-doc")
+
+	require.Error(t, err)
+	notFoundErr, ok := err.(*NotFoundError)
+	require.True(t, ok, "expected NotFoundError")
+	assert.Equal(t, 404, notFoundErr.StatusCode)
+}
+
 func TestTurboSignClient_Download(t *testing.T) {
 	expectedContent := []byte("%PDF-mock-content")
 	presignedURL := ""

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -329,6 +329,15 @@ zero once the document is terminal.
 `getLastWarningAt()`. It counts the signature request, resends, reminders, expiry warnings and
 terminal notices. CC notifications are excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `getReminderCount()` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `getTotalSent()`. So it can read `0` while reminder emails have genuinely been sent. |
+| `getLastRemindedAt()` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `getLastRemindedAt()` alongside `getReminderCount()` of `0`. |
+
+`getWarningCount()` and `getLastWarningAt()` are touched only by an expiry warning.
+
 #### `download()`
 
 Download the signed document.

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -273,13 +273,40 @@ for (RecipientResponse r : result.getRecipients()) {
 
 #### `getStatus()`
 
-Check the current status of a document.
+Check the document-level status. For per-recipient detail, use `getRecipients()`.
 
 ```java
 DocumentStatusResponse status = client.turboSign().getStatus("doc-uuid-here");
 
-System.out.println("Status: " + status.getStatus());  // "pending", "completed", "voided"
+System.out.println("Status: " + status.getStatus());  // "under_review", "completed", "voided"
 ```
+
+#### `getRecipients()`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```java
+DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-uuid-here");
+
+System.out.println("Sent by " + result.getDocument().getSentBy().getName()
+        + " <" + result.getDocument().getSentBy().getEmail() + ">");
+System.out.println(result.getSummary().getCompleted() + " of "
+        + result.getSummary().getTotal() + " signed, "
+        + result.getSummary().getPending() + " not started");
+
+for (DocumentRecipientsResponse.RecipientStatus r : result.getRecipients()) {
+    // "pending" | "viewed" | "completed"
+    System.out.println(r.getName() + " <" + r.getEmail() + ">: " + r.getStatus());
+    if (r.getSignedOn() != null) {
+        System.out.println("  signed " + r.getSignedOn());
+    }
+}
+```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `result.getDocument().getStatus()` before
+> treating someone as "still to sign".
 
 #### `download()`
 
@@ -990,6 +1017,7 @@ The `ManualTest.java` class tests all SDK methods:
 - ✅ `createSignatureReviewLink()` - Document upload for review
 - ✅ `sendSignature()` - Send for signature
 - ✅ `getStatus()` - Check document status
+- ✅ `getRecipients()` - Per-recipient signing status (who signed, who is pending)
 - ✅ `download()` - Download signed document
 - ✅ `voidDocument()` - Cancel signature request
 - ✅ `resendEmail()` - Resend signature emails

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -266,9 +266,14 @@ SendSignatureResponse result = client.turboSign().sendSignature(
         .build()
 );
 
+// The created recipients come back on the send result — each carries id, name and email.
+// Signing links are emailed to them; they are not returned here.
+// (RecipientResponse also exposes getSignUrl(), but the API never populates it.)
 for (RecipientResponse r : result.getRecipients()) {
-    System.out.println(r.getName() + ": " + r.getSignUrl());
+    System.out.println(r.getName() + " <" + r.getEmail() + "> — " + r.getId());
 }
+
+// For signing progress afterwards, use getRecipients().
 ```
 
 #### `getStatus()`

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -291,22 +291,38 @@ DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-uuid-h
 System.out.println("Sent by " + result.getDocument().getSentBy().getName()
         + " <" + result.getDocument().getSentBy().getEmail() + ">");
 System.out.println(result.getSummary().getCompleted() + " of "
-        + result.getSummary().getTotal() + " signed, "
-        + result.getSummary().getPending() + " not started");
+        + result.getSummary().getTotal() + " signed, still waiting on "
+        + result.getSummary().getWaitingOn());
 
 for (DocumentRecipientsResponse.RecipientStatus r : result.getRecipients()) {
-    // "pending" | "viewed" | "completed"
-    System.out.println(r.getName() + " <" + r.getEmail() + ">: " + r.getStatus());
+    // "pending" | "viewed" | "completed" | "voided" | "expired"
+    System.out.println(r.getName() + " <" + r.getEmail() + ">: " + r.getEffectiveStatus());
     if (r.getSignedOn() != null) {
         System.out.println("  signed " + r.getSignedOn());
     }
+    System.out.println("  emailed " + r.getDelivery().getTotalSent() + "x");
 }
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `result.getDocument().getStatus()` before
-> treating someone as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `getStatus()` | `pending`, `viewed`, `completed` | The raw database value |
+| `getEffectiveStatus()` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `getStatus()`. `getEffectiveStatus()`
+layers the document's outcome on top — that's the one to show a user. A completed signature
+is never revoked: someone who signed before the document was voided still reads `completed`.
+
+`getSummary()` counts by effective status, and `getWaitingOn()` (pending + viewed) drops to
+zero once the document is terminal.
+
+**`getDelivery()`** is that recipient's email history — `getFirstSentOn()`, `getLastSentOn()`,
+`getTotalSent()`, `getReminderCount()`, `getLastRemindedAt()`, `getWarningCount()`,
+`getLastWarningAt()`. It counts the signature request, resends, reminders, expiry warnings and
+terminal notices. CC notifications are excluded, since a CC address is not a signer.
 
 #### `download()`
 

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -294,7 +294,7 @@ System.out.println(result.getSummary().getCompleted() + " of "
         + result.getSummary().getTotal() + " signed, still waiting on "
         + result.getSummary().getWaitingOn());
 
-for (DocumentRecipientsResponse.RecipientStatus r : result.getRecipients()) {
+for (DocumentRecipientsResponse.RecipientSignatureStatus r : result.getRecipients()) {
     // "pending" | "viewed" | "completed" | "voided" | "expired"
     System.out.println(r.getName() + " <" + r.getEmail() + ">: " + r.getEffectiveStatus());
     if (r.getSignedOn() != null) {

--- a/packages/java-sdk/examples/TurboSignSendSimple.java
+++ b/packages/java-sdk/examples/TurboSignSendSimple.java
@@ -106,17 +106,20 @@ public class TurboSignSendSimple {
             System.out.println("Document ID: " + result.getDocumentId());
             System.out.println("Message: " + result.getMessage());
 
-            // To get sign URLs and recipient details, use getStatus
+            // Signing links are emailed to recipients — they are not returned by the API.
+            // getRecipients reports who has signed and who you are still waiting on.
             try {
-                DocumentStatusResponse status = client.turboSign().getStatus(result.getDocumentId());
-                if (status.getRecipients() != null) {
-                    System.out.println("\nSign URLs:");
-                    for (RecipientResponse recipient : status.getRecipients()) {
-                        System.out.println("  " + recipient.getName() + ": " + recipient.getSignUrl());
-                    }
+                DocumentRecipientsResponse progress =
+                        client.turboSign().getRecipients(result.getDocumentId());
+                System.out.println("\n" + progress.getSummary().getCompleted() + " of "
+                        + progress.getSummary().getTotal() + " signed, still waiting on "
+                        + progress.getSummary().getWaitingOn());
+                for (DocumentRecipientsResponse.RecipientSignatureStatus recipient : progress.getRecipients()) {
+                    System.out.println("  " + recipient.getName() + " <" + recipient.getEmail()
+                            + ">: " + recipient.getEffectiveStatus());
                 }
             } catch (Exception statusError) {
-                System.out.println("\nNote: Could not fetch recipient sign URLs");
+                System.out.println("\nNote: Could not fetch recipient status");
             }
 
         } catch (Exception error) {

--- a/packages/java-sdk/src/main/java/com/turbodocx/TurboSign.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/TurboSign.java
@@ -123,6 +123,20 @@ public final class TurboSign {
     }
 
     /**
+     * Get every recipient on a document with their signing status.
+     *
+     * <p>Answers "who has signed and who are we still waiting on" in one call, and reports who
+     * sent the document. {@link DocumentRecipientsResponse#getSummary()} carries the
+     * pending/viewed/completed counts.
+     */
+    public DocumentRecipientsResponse getRecipients(String documentId) throws IOException {
+        return httpClient.get(
+                "/turbosign/documents/" + documentId + "/recipients",
+                DocumentRecipientsResponse.class
+        );
+    }
+
+    /**
      * Download the signed document.
      * The backend returns a presigned S3 URL, which this method fetches.
      */

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
@@ -49,6 +49,9 @@ public class DocumentRecipientsResponse {
         @SerializedName("createdOn")
         private String createdOn;
 
+        @SerializedName("sentOn")
+        private String sentOn;
+
         @SerializedName("expiresAt")
         private String expiresAt;
 
@@ -70,6 +73,11 @@ public class DocumentRecipientsResponse {
 
         public String getCreatedOn() {
             return createdOn;
+        }
+
+        /** When the document was dispatched to recipients; null while it is still a draft. */
+        public String getSentOn() {
+            return sentOn;
         }
 
         /** When the signing window closes; null when the document never expires. */
@@ -118,11 +126,17 @@ public class DocumentRecipientsResponse {
         @SerializedName("status")
         private String status;
 
+        @SerializedName("effectiveStatus")
+        private String effectiveStatus;
+
         @SerializedName("signedOn")
         private String signedOn;
 
         @SerializedName("signingOrder")
         private int signingOrder;
+
+        @SerializedName("delivery")
+        private RecipientDelivery delivery;
 
         public String getId() {
             return id;
@@ -136,9 +150,19 @@ public class DocumentRecipientsResponse {
             return email;
         }
 
-        /** One of {@code pending}, {@code viewed}, {@code completed}. */
+        /** Raw database status — only ever {@code pending}, {@code viewed} or {@code completed}. */
         public String getStatus() {
             return status;
+        }
+
+        /**
+         * Raw status with the document's terminal state layered on: {@code pending},
+         * {@code viewed}, {@code completed}, {@code voided} or {@code expired}. Use this for
+         * display — a signer on a voided document reads {@code voided} here but still
+         * {@code pending} in {@link #getStatus()}. A completed signature is never revoked.
+         */
+        public String getEffectiveStatus() {
+            return effectiveStatus;
         }
 
         /** When this recipient completed signing; null while pending or viewed. */
@@ -148,6 +172,69 @@ public class DocumentRecipientsResponse {
 
         public int getSigningOrder() {
             return signingOrder;
+        }
+
+        /** Email history for this recipient. */
+        public RecipientDelivery getDelivery() {
+            return delivery;
+        }
+    }
+
+    /**
+     * Email history for one recipient — every notification actually sent to them.
+     * CC notifications are excluded; a CC address is not a signer.
+     */
+    public static class RecipientDelivery {
+        @SerializedName("firstSentOn")
+        private String firstSentOn;
+
+        @SerializedName("lastSentOn")
+        private String lastSentOn;
+
+        @SerializedName("totalSent")
+        private int totalSent;
+
+        @SerializedName("reminderCount")
+        private int reminderCount;
+
+        @SerializedName("lastRemindedAt")
+        private String lastRemindedAt;
+
+        @SerializedName("warningCount")
+        private int warningCount;
+
+        @SerializedName("lastWarningAt")
+        private String lastWarningAt;
+
+        /** First email of any kind to this recipient; null if they have never been emailed. */
+        public String getFirstSentOn() {
+            return firstSentOn;
+        }
+
+        /** Most recent email of any kind to this recipient. */
+        public String getLastSentOn() {
+            return lastSentOn;
+        }
+
+        /** Total emails sent (request, resends, reminders, warnings, terminal notices). */
+        public int getTotalSent() {
+            return totalSent;
+        }
+
+        public int getReminderCount() {
+            return reminderCount;
+        }
+
+        public String getLastRemindedAt() {
+            return lastRemindedAt;
+        }
+
+        public int getWarningCount() {
+            return warningCount;
+        }
+
+        public String getLastWarningAt() {
+            return lastWarningAt;
         }
     }
 
@@ -167,6 +254,15 @@ public class DocumentRecipientsResponse {
         @SerializedName("completed")
         private int completed;
 
+        @SerializedName("voided")
+        private int voided;
+
+        @SerializedName("expired")
+        private int expired;
+
+        @SerializedName("waitingOn")
+        private int waitingOn;
+
         public int getTotal() {
             return total;
         }
@@ -181,6 +277,21 @@ public class DocumentRecipientsResponse {
 
         public int getCompleted() {
             return completed;
+        }
+
+        /** Signers stranded by a voided document. */
+        public int getVoided() {
+            return voided;
+        }
+
+        /** Signers stranded by an expired document. */
+        public int getExpired() {
+            return expired;
+        }
+
+        /** Recipients who can still act (pending + viewed). Zero once the document is terminal. */
+        public int getWaitingOn() {
+            return waitingOn;
         }
     }
 }

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
@@ -1,0 +1,186 @@
+package com.turbodocx.models;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.List;
+
+/**
+ * Response from getting a document's recipients with their per-recipient signing status.
+ *
+ * <p>Recipient status is one of {@code pending}, {@code viewed} or {@code completed}. There is
+ * no per-recipient declined/expired/voided state, so on a voided or expired document every
+ * unsigned recipient still reads {@code pending} — read {@link RecipientsDocument#getStatus()}
+ * to tell "still waiting" apart from "this document is dead".
+ */
+public class DocumentRecipientsResponse {
+    @SerializedName("document")
+    private RecipientsDocument document;
+
+    @SerializedName("recipients")
+    private List<RecipientStatus> recipients;
+
+    @SerializedName("summary")
+    private RecipientStatusSummary summary;
+
+    public RecipientsDocument getDocument() {
+        return document;
+    }
+
+    public List<RecipientStatus> getRecipients() {
+        return recipients;
+    }
+
+    public RecipientStatusSummary getSummary() {
+        return summary;
+    }
+
+    /**
+     * The document the recipients belong to.
+     */
+    public static class RecipientsDocument {
+        @SerializedName("id")
+        private String id;
+
+        @SerializedName("name")
+        private String name;
+
+        @SerializedName("status")
+        private String status;
+
+        @SerializedName("createdOn")
+        private String createdOn;
+
+        @SerializedName("expiresAt")
+        private String expiresAt;
+
+        @SerializedName("sentBy")
+        private Sender sentBy;
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        /** Document-level status, e.g. {@code under_review}, {@code completed}, {@code voided}. */
+        public String getStatus() {
+            return status;
+        }
+
+        public String getCreatedOn() {
+            return createdOn;
+        }
+
+        /** When the signing window closes; null when the document never expires. */
+        public String getExpiresAt() {
+            return expiresAt;
+        }
+
+        /** Who sent the document — never the synthetic API service account. */
+        public Sender getSentBy() {
+            return sentBy;
+        }
+    }
+
+    /**
+     * The identity that sent the document for signature.
+     */
+    public static class Sender {
+        @SerializedName("name")
+        private String name;
+
+        @SerializedName("email")
+        private String email;
+
+        public String getName() {
+            return name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+    }
+
+    /**
+     * A single recipient and where they are in the signing process.
+     */
+    public static class RecipientStatus {
+        @SerializedName("id")
+        private String id;
+
+        @SerializedName("name")
+        private String name;
+
+        @SerializedName("email")
+        private String email;
+
+        @SerializedName("status")
+        private String status;
+
+        @SerializedName("signedOn")
+        private String signedOn;
+
+        @SerializedName("signingOrder")
+        private int signingOrder;
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        /** One of {@code pending}, {@code viewed}, {@code completed}. */
+        public String getStatus() {
+            return status;
+        }
+
+        /** When this recipient completed signing; null while pending or viewed. */
+        public String getSignedOn() {
+            return signedOn;
+        }
+
+        public int getSigningOrder() {
+            return signingOrder;
+        }
+    }
+
+    /**
+     * Roll-up of the roster so callers can answer "how many are we waiting on" without looping.
+     */
+    public static class RecipientStatusSummary {
+        @SerializedName("total")
+        private int total;
+
+        @SerializedName("pending")
+        private int pending;
+
+        @SerializedName("viewed")
+        private int viewed;
+
+        @SerializedName("completed")
+        private int completed;
+
+        public int getTotal() {
+            return total;
+        }
+
+        public int getPending() {
+            return pending;
+        }
+
+        public int getViewed() {
+            return viewed;
+        }
+
+        public int getCompleted() {
+            return completed;
+        }
+    }
+}

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
@@ -223,18 +223,34 @@ public class DocumentRecipientsResponse {
             return totalSent;
         }
 
+        /**
+         * Automatic (scheduled) reminders only — the counter {@code maxReminders} caps.
+         * A manual "remind now" does NOT increment it (it must not consume the cap budget),
+         * though it does land in {@link #getTotalSent()}. So this can read 0 while reminder
+         * emails have genuinely been sent.
+         */
         public int getReminderCount() {
             return reminderCount;
         }
 
+        /**
+         * When the reminder cadence clock was last reset — NOT necessarily when a reminder
+         * was sent. Stamped by the initial signature-request send, each scheduled reminder,
+         * each manual "remind now", and each expiry warning. Only scheduled reminders bump
+         * {@link #getReminderCount()}, so a freshly-sent document normally shows a non-null
+         * value here alongside a reminder count of 0. Null means "never emailed on this
+         * cadence".
+         */
         public String getLastRemindedAt() {
             return lastRemindedAt;
         }
 
+        /** Expiry warnings sent. Only a warning touches this. */
         public int getWarningCount() {
             return warningCount;
         }
 
+        /** When the last expiry warning went out. Only a warning touches this. */
         public String getLastWarningAt() {
             return lastWarningAt;
         }

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/DocumentRecipientsResponse.java
@@ -6,17 +6,19 @@ import java.util.List;
 /**
  * Response from getting a document's recipients with their per-recipient signing status.
  *
- * <p>Recipient status is one of {@code pending}, {@code viewed} or {@code completed}. There is
- * no per-recipient declined/expired/voided state, so on a voided or expired document every
- * unsigned recipient still reads {@code pending} — read {@link RecipientsDocument#getStatus()}
- * to tell "still waiting" apart from "this document is dead".
+ * <p>Each recipient carries two status fields on purpose.
+ * {@link RecipientSignatureStatus#getStatus()} is the raw database value and is only ever
+ * {@code pending}, {@code viewed} or {@code completed} — the schema has no per-recipient
+ * declined/voided/expired state. {@link RecipientSignatureStatus#getEffectiveStatus()} layers
+ * the document's outcome on top ({@code voided}, {@code expired}) and is the one to display.
+ * A completed signature is never revoked.
  */
 public class DocumentRecipientsResponse {
     @SerializedName("document")
     private RecipientsDocument document;
 
     @SerializedName("recipients")
-    private List<RecipientStatus> recipients;
+    private List<RecipientSignatureStatus> recipients;
 
     @SerializedName("summary")
     private RecipientStatusSummary summary;
@@ -25,7 +27,7 @@ public class DocumentRecipientsResponse {
         return document;
     }
 
-    public List<RecipientStatus> getRecipients() {
+    public List<RecipientSignatureStatus> getRecipients() {
         return recipients;
     }
 
@@ -56,7 +58,7 @@ public class DocumentRecipientsResponse {
         private String expiresAt;
 
         @SerializedName("sentBy")
-        private Sender sentBy;
+        private DocumentSender sentBy;
 
         public String getId() {
             return id;
@@ -86,7 +88,7 @@ public class DocumentRecipientsResponse {
         }
 
         /** Who sent the document — never the synthetic API service account. */
-        public Sender getSentBy() {
+        public DocumentSender getSentBy() {
             return sentBy;
         }
     }
@@ -94,7 +96,7 @@ public class DocumentRecipientsResponse {
     /**
      * The identity that sent the document for signature.
      */
-    public static class Sender {
+    public static class DocumentSender {
         @SerializedName("name")
         private String name;
 
@@ -113,7 +115,7 @@ public class DocumentRecipientsResponse {
     /**
      * A single recipient and where they are in the signing process.
      */
-    public static class RecipientStatus {
+    public static class RecipientSignatureStatus {
         @SerializedName("id")
         private String id;
 

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
@@ -361,7 +361,7 @@ class TurboSignTest {
             + "\"signedOn\":null,\"signingOrder\":2,"
             + "\"delivery\":{\"firstSentOn\":\"2026-01-02T09:00:00.000Z\","
             + "\"lastSentOn\":\"2026-01-02T09:00:00.000Z\",\"totalSent\":1,"
-            + "\"reminderCount\":0,\"lastRemindedAt\":null,"
+            + "\"reminderCount\":0,\"lastRemindedAt\":\"2026-01-02T09:00:00.000Z\","
             + "\"warningCount\":0,\"lastWarningAt\":null}}],"
             + "\"summary\":{\"total\":2,\"pending\":1,\"viewed\":0,\"completed\":1,"
             + "\"voided\":0,\"expired\":0,\"waitingOn\":1}}}";
@@ -450,11 +450,13 @@ class TurboSignTest {
         assertEquals(1, chased.getReminderCount());
         assertEquals(0, chased.getWarningCount());
 
-        // A recipient emailed once has matching first/last and no reminders
+        // Emailed once and never reminded: reminder count stays 0, but lastRemindedAt is
+        // NOT null — the initial send stamps it as the reminder cadence clock.
         DocumentRecipientsResponse.RecipientDelivery once = result.getRecipients().get(1).getDelivery();
         assertEquals(1, once.getTotalSent());
+        assertEquals(0, once.getReminderCount());
         assertEquals(once.getFirstSentOn(), once.getLastSentOn());
-        assertNull(once.getLastRemindedAt());
+        assertEquals(once.getFirstSentOn(), once.getLastRemindedAt());
     }
 
     @Test

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
@@ -339,6 +339,78 @@ class TurboSignTest {
     }
 
     // ============================================
+    // GetRecipients Tests (3)
+    // ============================================
+
+    /** The wire shape the backend returns, envelope included. */
+    private static final String RECIPIENTS_BODY = "{\"data\":{"
+            + "\"document\":{\"id\":\"doc-123\",\"name\":\"Mutual NDA\",\"status\":\"under_review\","
+            + "\"createdOn\":\"2026-01-01T00:00:00.000Z\",\"expiresAt\":null,"
+            + "\"sentBy\":{\"name\":\"Jane Sender\",\"email\":\"jane@acme.com\"}},"
+            + "\"recipients\":["
+            + "{\"id\":\"rec-1\",\"name\":\"John Signer\",\"email\":\"john@example.com\","
+            + "\"status\":\"completed\",\"signedOn\":\"2026-02-01T10:00:00.000Z\",\"signingOrder\":1},"
+            + "{\"id\":\"rec-2\",\"name\":\"Ada Signer\",\"email\":\"ada@example.com\","
+            + "\"status\":\"pending\",\"signedOn\":null,\"signingOrder\":2}],"
+            + "\"summary\":{\"total\":2,\"pending\":1,\"viewed\":0,\"completed\":1}}}";
+
+    @Test
+    @DisplayName("should get every recipient with their signing status")
+    void getRecipients() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(RECIPIENTS_BODY));
+
+        DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-123");
+
+        assertEquals(2, result.getRecipients().size());
+        assertEquals("completed", result.getRecipients().get(0).getStatus());
+        assertEquals("john@example.com", result.getRecipients().get(0).getEmail());
+        assertEquals("2026-02-01T10:00:00.000Z", result.getRecipients().get(0).getSignedOn());
+        assertEquals(1, result.getRecipients().get(0).getSigningOrder());
+        // A pending signer has no signedOn timestamp
+        assertNull(result.getRecipients().get(1).getSignedOn());
+        assertEquals("pending", result.getRecipients().get(1).getStatus());
+
+        RecordedRequest recorded = server.takeRequest();
+        assertEquals("GET", recorded.getMethod());
+        assertEquals("/turbosign/documents/doc-123/recipients", recorded.getPath());
+    }
+
+    @Test
+    @DisplayName("should expose who sent the document and the pending/completed roll-up")
+    void getRecipientsSummaryAndSender() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(RECIPIENTS_BODY));
+
+        DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-123");
+
+        assertEquals("Jane Sender", result.getDocument().getSentBy().getName());
+        assertEquals("jane@acme.com", result.getDocument().getSentBy().getEmail());
+        // Document status is what distinguishes a voided/expired doc from one still waiting
+        assertEquals("under_review", result.getDocument().getStatus());
+        assertEquals(2, result.getSummary().getTotal());
+        assertEquals(1, result.getSummary().getPending());
+        assertEquals(0, result.getSummary().getViewed());
+        assertEquals(1, result.getSummary().getCompleted());
+    }
+
+    @Test
+    @DisplayName("should throw NotFoundException for an unknown document")
+    void getRecipientsNotFound() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(404)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"message\":\"Document not found\",\"type\":\"DocumentNotFound\"}"));
+
+        assertThrows(TurboDocxException.NotFoundException.class,
+                () -> client.turboSign().getRecipients("missing-doc"));
+    }
+
+    // ============================================
     // Void Test (1)
     // ============================================
 

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboSignTest.java
@@ -345,14 +345,44 @@ class TurboSignTest {
     /** The wire shape the backend returns, envelope included. */
     private static final String RECIPIENTS_BODY = "{\"data\":{"
             + "\"document\":{\"id\":\"doc-123\",\"name\":\"Mutual NDA\",\"status\":\"under_review\","
-            + "\"createdOn\":\"2026-01-01T00:00:00.000Z\",\"expiresAt\":null,"
+            + "\"createdOn\":\"2026-01-01T00:00:00.000Z\",\"sentOn\":\"2026-01-02T08:59:00.000Z\","
+            + "\"expiresAt\":null,"
             + "\"sentBy\":{\"name\":\"Jane Sender\",\"email\":\"jane@acme.com\"}},"
             + "\"recipients\":["
             + "{\"id\":\"rec-1\",\"name\":\"John Signer\",\"email\":\"john@example.com\","
-            + "\"status\":\"completed\",\"signedOn\":\"2026-02-01T10:00:00.000Z\",\"signingOrder\":1},"
+            + "\"status\":\"completed\",\"effectiveStatus\":\"completed\","
+            + "\"signedOn\":\"2026-02-01T10:00:00.000Z\",\"signingOrder\":1,"
+            + "\"delivery\":{\"firstSentOn\":\"2026-01-02T09:00:00.000Z\","
+            + "\"lastSentOn\":\"2026-01-09T09:00:00.000Z\",\"totalSent\":3,"
+            + "\"reminderCount\":1,\"lastRemindedAt\":\"2026-01-09T09:00:00.000Z\","
+            + "\"warningCount\":0,\"lastWarningAt\":null}},"
             + "{\"id\":\"rec-2\",\"name\":\"Ada Signer\",\"email\":\"ada@example.com\","
-            + "\"status\":\"pending\",\"signedOn\":null,\"signingOrder\":2}],"
-            + "\"summary\":{\"total\":2,\"pending\":1,\"viewed\":0,\"completed\":1}}}";
+            + "\"status\":\"pending\",\"effectiveStatus\":\"pending\","
+            + "\"signedOn\":null,\"signingOrder\":2,"
+            + "\"delivery\":{\"firstSentOn\":\"2026-01-02T09:00:00.000Z\","
+            + "\"lastSentOn\":\"2026-01-02T09:00:00.000Z\",\"totalSent\":1,"
+            + "\"reminderCount\":0,\"lastRemindedAt\":null,"
+            + "\"warningCount\":0,\"lastWarningAt\":null}}],"
+            + "\"summary\":{\"total\":2,\"pending\":1,\"viewed\":0,\"completed\":1,"
+            + "\"voided\":0,\"expired\":0,\"waitingOn\":1}}}";
+
+    /** A voided document: the unsigned signer reads voided, the signed one stays completed. */
+    private static final String VOIDED_RECIPIENTS_BODY = "{\"data\":{"
+            + "\"document\":{\"id\":\"doc-123\",\"name\":\"Mutual NDA\",\"status\":\"voided\","
+            + "\"createdOn\":\"2026-01-01T00:00:00.000Z\",\"sentOn\":\"2026-01-02T08:59:00.000Z\","
+            + "\"expiresAt\":null,"
+            + "\"sentBy\":{\"name\":\"Jane Sender\",\"email\":\"jane@acme.com\"}},"
+            + "\"recipients\":["
+            + "{\"id\":\"rec-1\",\"name\":\"John Signer\",\"email\":\"john@example.com\","
+            + "\"status\":\"completed\",\"effectiveStatus\":\"completed\","
+            + "\"signedOn\":\"2026-02-01T10:00:00.000Z\",\"signingOrder\":1,"
+            + "\"delivery\":{\"totalSent\":1,\"reminderCount\":0,\"warningCount\":0}},"
+            + "{\"id\":\"rec-2\",\"name\":\"Ada Signer\",\"email\":\"ada@example.com\","
+            + "\"status\":\"pending\",\"effectiveStatus\":\"voided\","
+            + "\"signedOn\":null,\"signingOrder\":2,"
+            + "\"delivery\":{\"totalSent\":1,\"reminderCount\":0,\"warningCount\":0}}],"
+            + "\"summary\":{\"total\":2,\"pending\":0,\"viewed\":0,\"completed\":1,"
+            + "\"voided\":1,\"expired\":0,\"waitingOn\":0}}}";
 
     @Test
     @DisplayName("should get every recipient with their signing status")
@@ -366,6 +396,7 @@ class TurboSignTest {
 
         assertEquals(2, result.getRecipients().size());
         assertEquals("completed", result.getRecipients().get(0).getStatus());
+        assertEquals("completed", result.getRecipients().get(0).getEffectiveStatus());
         assertEquals("john@example.com", result.getRecipients().get(0).getEmail());
         assertEquals("2026-02-01T10:00:00.000Z", result.getRecipients().get(0).getSignedOn());
         assertEquals(1, result.getRecipients().get(0).getSigningOrder());
@@ -392,10 +423,57 @@ class TurboSignTest {
         assertEquals("jane@acme.com", result.getDocument().getSentBy().getEmail());
         // Document status is what distinguishes a voided/expired doc from one still waiting
         assertEquals("under_review", result.getDocument().getStatus());
+        assertEquals("2026-01-02T08:59:00.000Z", result.getDocument().getSentOn());
         assertEquals(2, result.getSummary().getTotal());
         assertEquals(1, result.getSummary().getPending());
         assertEquals(0, result.getSummary().getViewed());
         assertEquals(1, result.getSummary().getCompleted());
+        assertEquals(0, result.getSummary().getVoided());
+        assertEquals(0, result.getSummary().getExpired());
+        assertEquals(1, result.getSummary().getWaitingOn());
+    }
+
+    @Test
+    @DisplayName("should report each recipient's email history")
+    void getRecipientsDelivery() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(RECIPIENTS_BODY));
+
+        DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-123");
+
+        DocumentRecipientsResponse.RecipientDelivery chased = result.getRecipients().get(0).getDelivery();
+        assertEquals(3, chased.getTotalSent());
+        assertEquals("2026-01-02T09:00:00.000Z", chased.getFirstSentOn());
+        assertEquals("2026-01-09T09:00:00.000Z", chased.getLastSentOn());
+        assertEquals(1, chased.getReminderCount());
+        assertEquals(0, chased.getWarningCount());
+
+        // A recipient emailed once has matching first/last and no reminders
+        DocumentRecipientsResponse.RecipientDelivery once = result.getRecipients().get(1).getDelivery();
+        assertEquals(1, once.getTotalSent());
+        assertEquals(once.getFirstSentOn(), once.getLastSentOn());
+        assertNull(once.getLastRemindedAt());
+    }
+
+    @Test
+    @DisplayName("should surface voided as a recipient's effective status without revoking a signature")
+    void getRecipientsEffectiveStatusOnVoidedDocument() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(VOIDED_RECIPIENTS_BODY));
+
+        DocumentRecipientsResponse result = client.turboSign().getRecipients("doc-123");
+
+        // Someone who signed still signed — voiding the document does not undo it
+        assertEquals("completed", result.getRecipients().get(0).getEffectiveStatus());
+        // The unsigned signer is stranded, even though the raw DB status is still "pending"
+        assertEquals("pending", result.getRecipients().get(1).getStatus());
+        assertEquals("voided", result.getRecipients().get(1).getEffectiveStatus());
+        assertEquals(1, result.getSummary().getVoided());
+        assertEquals(0, result.getSummary().getWaitingOn());
     }
 
     @Test

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -243,10 +243,13 @@ const result = await TurboSign.sendSignature({
   ]
 });
 
-// Each recipient gets a unique signing URL
-result.recipients.forEach(r => {
-  console.log(`${r.name}: ${r.signUrl}`);
+// The created recipients come back on the send result (id, name, email).
+// Signing links are emailed to them — they are not returned here.
+result.recipients?.forEach(r => {
+  console.log(`${r.name} <${r.email}> — ${r.id}`);
 });
+
+// For signing progress afterwards, use getRecipients().
 ```
 
 #### `getStatus(documentId)`

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -251,19 +251,38 @@ result.recipients.forEach(r => {
 
 #### `getStatus(documentId)`
 
-Check the current status of a document.
+Check the document-level status. For per-recipient detail, use
+[`getRecipients()`](#getrecipientsdocumentid).
 
 ```typescript
 const status = await TurboSign.getStatus('doc-uuid-here');
 
-console.log('Document Status:', status.status);  // 'pending' | 'completed' | 'voided'
-console.log('Recipients:', status.recipients);
-
-// Check individual recipient status
-status.recipients.forEach(r => {
-  console.log(`${r.name}: ${r.status}`);  // 'pending' | 'signed' | 'declined'
-});
+console.log('Document Status:', status.status);  // 'under_review' | 'completed' | 'voided' | ...
 ```
+
+#### `getRecipients(documentId)`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```typescript
+const { document, recipients, summary } = await TurboSign.getRecipients('doc-uuid-here');
+
+console.log(`Sent by ${document.sentBy.name} <${document.sentBy.email}>`);
+console.log(`${summary.completed} of ${summary.total} signed, ${summary.pending} not started`);
+
+recipients.forEach(r => {
+  console.log(`${r.name} <${r.email}>: ${r.status}`);  // 'pending' | 'viewed' | 'completed'
+  if (r.signedOn) console.log(`  signed ${r.signedOn}`);
+});
+
+// Who are we chasing?
+const waitingOn = recipients.filter(r => r.status !== 'completed');
+```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `document.status` before treating someone
+> as "still to sign".
 
 #### `download(documentId)`
 
@@ -892,6 +911,7 @@ The `manual-test.ts` file tests all SDK methods:
 - ✅ `createSignatureReviewLink()` - Document upload for review
 - ✅ `sendSignature()` - Send for signature
 - ✅ `getStatus()` - Check document status
+- ✅ `getRecipients()` - Per-recipient signing status (who signed, who is pending)
 - ✅ `download()` - Download signed document
 - ✅ `void()` - Cancel signature request
 - ✅ `resend()` - Resend signature emails

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -268,21 +268,40 @@ See who the document went to, who has signed, who you are still waiting on, and 
 const { document, recipients, summary } = await TurboSign.getRecipients('doc-uuid-here');
 
 console.log(`Sent by ${document.sentBy.name} <${document.sentBy.email}>`);
-console.log(`${summary.completed} of ${summary.total} signed, ${summary.pending} not started`);
+console.log(`Sent on ${document.sentOn ?? 'not sent yet'}`);
+console.log(`${summary.completed} of ${summary.total} signed, still waiting on ${summary.waitingOn}`);
 
 recipients.forEach(r => {
-  console.log(`${r.name} <${r.email}>: ${r.status}`);  // 'pending' | 'viewed' | 'completed'
+  // 'pending' | 'viewed' | 'completed' | 'voided' | 'expired'
+  console.log(`${r.name} <${r.email}>: ${r.effectiveStatus}`);
   if (r.signedOn) console.log(`  signed ${r.signedOn}`);
+  console.log(`  emailed ${r.delivery.totalSent}x, last ${r.delivery.lastSentOn ?? 'never'}`);
+  if (r.delivery.reminderCount) console.log(`  reminded ${r.delivery.reminderCount}x`);
 });
 
 // Who are we chasing?
-const waitingOn = recipients.filter(r => r.status !== 'completed');
+const chasing = recipients.filter(r => r.effectiveStatus === 'pending' || r.effectiveStatus === 'viewed');
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `document.status` before treating someone
-> as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `status` | `pending`, `viewed`, `completed` | The raw database value |
+| `effectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `status`. `effectiveStatus` layers the
+document's outcome on top — that's the one to show a user. A completed signature is never
+revoked: someone who signed before the document was voided still reads `completed`.
+
+`summary` counts by `effectiveStatus`, and `waitingOn` (pending + viewed) drops to zero once
+the document is terminal.
+
+**`delivery`** is that recipient's email history — `firstSentOn`, `lastSentOn`, `totalSent`,
+`reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt`. It counts the signature
+request, resends, reminders, expiry warnings and terminal notices. CC notifications are
+excluded, since a CC address is not a signer.
 
 #### `download(documentId)`
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -306,6 +306,15 @@ the document is terminal.
 request, resends, reminders, expiry warnings and terminal notices. CC notifications are
 excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `reminderCount` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `totalSent`. So it can read `0` while reminder emails have genuinely been sent. |
+| `lastRemindedAt` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `lastRemindedAt` alongside `reminderCount` of `0`. |
+
+`warningCount` and `lastWarningAt` are touched only by an expiry warning.
+
 #### `download(documentId)`
 
 Download the signed document as a Buffer/Blob.

--- a/packages/js-sdk/examples/turbosign-send-simple.ts
+++ b/packages/js-sdk/examples/turbosign-send-simple.ts
@@ -103,17 +103,18 @@ async function sendDirectlyExample() {
     console.log('Document ID:', result.documentId);
     console.log('Message:', result.message);
 
-    // To get sign URLs and recipient details, use getStatus
+    // Signing links are emailed to recipients — they are not returned by the API.
+    // getRecipients reports who has signed and who you are still waiting on.
     try {
-      const status = await TurboSign.getStatus(result.documentId);
-      if (status?.recipients) {
-        console.log('\nSign URLs:');
-        status.recipients.forEach(recipient => {
-          console.log(`  ${recipient.name}: ${recipient.signUrl}`);
-        });
-      }
+      const { recipients, summary } = await TurboSign.getRecipients(result.documentId);
+      console.log(
+        `\n${summary.completed} of ${summary.total} signed, still waiting on ${summary.waitingOn}`
+      );
+      recipients.forEach(recipient => {
+        console.log(`  ${recipient.name} <${recipient.email}>: ${recipient.effectiveStatus}`);
+      });
     } catch (statusError) {
-      console.log('\nNote: Could not fetch recipient sign URLs');
+      console.log('\nNote: Could not fetch recipient status');
     }
 
   } catch (error) {

--- a/packages/js-sdk/src/modules/sign.ts
+++ b/packages/js-sdk/src/modules/sign.ts
@@ -355,13 +355,21 @@ export class TurboSign {
    * Get every recipient on a document with their signing status
    *
    * Answers "who has signed and who are we still waiting on" in one call, and reports who
-   * sent the document. `summary` carries the pending/viewed/completed counts.
+   * sent the document. `summary` carries the counts, including `waitingOn`.
+   *
+   * Branch on `effectiveStatus`, not `status`: `status` is the raw database value and is
+   * only ever 'pending' | 'viewed' | 'completed', so on a voided or expired document an
+   * unsigned signer still reads 'pending' there. `effectiveStatus` layers the document's
+   * outcome on top, adding 'voided' and 'expired'.
    *
    * @example
    * ```typescript
    * const { recipients, summary, document } = await TurboSign.getRecipients(documentId);
    * console.log(`${summary.completed}/${summary.total} signed, sent by ${document.sentBy.name}`);
-   * const waitingOn = recipients.filter((r) => r.status !== 'completed');
+   * console.log(`still waiting on ${summary.waitingOn}`);
+   * const chasing = recipients.filter(
+   *   (r) => r.effectiveStatus === 'pending' || r.effectiveStatus === 'viewed',
+   * );
    * ```
    */
   static async getRecipients(documentId: string): Promise<DocumentRecipientsResponse> {

--- a/packages/js-sdk/src/modules/sign.ts
+++ b/packages/js-sdk/src/modules/sign.ts
@@ -9,6 +9,7 @@ import {
   ResendEmailResponse,
   AuditTrailResponse,
   DocumentStatusResponse,
+  DocumentRecipientsResponse,
   CreateSignatureReviewLinkRequest,
   CreateSignatureReviewLinkResponse,
   SendSignatureRequest,
@@ -348,5 +349,24 @@ export class TurboSign {
     const client = this.getClient();
     // HTTP client auto-unwraps {data: ...} responses
     return client.get<DocumentStatusResponse>(`/turbosign/documents/${documentId}/status`);
+  }
+
+  /**
+   * Get every recipient on a document with their signing status
+   *
+   * Answers "who has signed and who are we still waiting on" in one call, and reports who
+   * sent the document. `summary` carries the pending/viewed/completed counts.
+   *
+   * @example
+   * ```typescript
+   * const { recipients, summary, document } = await TurboSign.getRecipients(documentId);
+   * console.log(`${summary.completed}/${summary.total} signed, sent by ${document.sentBy.name}`);
+   * const waitingOn = recipients.filter((r) => r.status !== 'completed');
+   * ```
+   */
+  static async getRecipients(documentId: string): Promise<DocumentRecipientsResponse> {
+    const client = this.getClient();
+    // HTTP client auto-unwraps {data: ...} responses
+    return client.get<DocumentRecipientsResponse>(`/turbosign/documents/${documentId}/recipients`);
   }
 }

--- a/packages/js-sdk/src/types/sign.ts
+++ b/packages/js-sdk/src/types/sign.ts
@@ -131,9 +131,24 @@ export interface RecipientDelivery {
   lastSentOn: string | null;
   /** Total emails sent (request, resends, reminders, warnings, terminal notices). */
   totalSent: number;
+  /**
+   * Automatic (scheduled) reminders only — the counter `maxReminders` caps. A manual
+   * "remind now" does NOT increment it (it is a standalone nudge that must not consume
+   * the cap budget), though it does land in `totalSent`. So this can read 0 while
+   * reminder emails have genuinely been sent.
+   */
   reminderCount: number;
+  /**
+   * When the reminder cadence clock was last reset — NOT necessarily when a reminder was
+   * sent. Stamped by the initial signature-request send, each scheduled reminder, each
+   * manual "remind now", and each expiry warning. Only scheduled reminders bump
+   * `reminderCount`, so a freshly-sent document normally shows a non-null value here
+   * alongside `reminderCount: 0`. Null means "never emailed on this cadence".
+   */
   lastRemindedAt: string | null;
+  /** Expiry warnings sent. Only a warning touches this. */
   warningCount: number;
+  /** When the last expiry warning went out. Only a warning touches this. */
   lastWarningAt: string | null;
 }
 

--- a/packages/js-sdk/src/types/sign.ts
+++ b/packages/js-sdk/src/types/sign.ts
@@ -176,24 +176,23 @@ export interface DocumentSender {
   email: string;
 }
 
+/** The document a set of recipients belongs to. */
+export interface RecipientsDocument {
+  id: string;
+  name: string;
+  /** Document-level status — the full SignatureDocumentStatus set. */
+  status: string;
+  createdOn: string;
+  /** When the document was dispatched to recipients; null while it is still a draft. */
+  sentOn: string | null;
+  /** When the signing window closes; null when the document never expires. */
+  expiresAt: string | null;
+  /** Who sent it — never the synthetic API service account. */
+  sentBy: DocumentSender;
+}
+
 export interface DocumentRecipientsResponse {
-  document: {
-    id: string;
-    name: string;
-    /**
-     * Document-level status. There is no per-recipient declined/expired/voided state, so on a
-     * voided or expired document every unsigned recipient still reads 'pending' — read this to
-     * tell "still waiting" apart from "this document is dead".
-     */
-    status: string;
-    createdOn: string;
-    /** When the document was dispatched to recipients; null while it is still a draft. */
-    sentOn: string | null;
-    /** When the signing window closes; null when the document never expires. */
-    expiresAt: string | null;
-    /** Who sent it — never the synthetic API service account. */
-    sentBy: DocumentSender;
-  };
+  document: RecipientsDocument;
   recipients: RecipientSignatureStatus[];
   summary: RecipientStatusSummary;
 }

--- a/packages/js-sdk/src/types/sign.ts
+++ b/packages/js-sdk/src/types/sign.ts
@@ -113,24 +113,61 @@ export interface DocumentStatusResponse {
   status: string;
 }
 
+/**
+ * A recipient's status once the document's own terminal state is layered on top.
+ * The database only stores pending/viewed/completed; voided and expired are projected
+ * from the document onto signers who had not finished.
+ */
+export type RecipientEffectiveStatus = 'pending' | 'viewed' | 'completed' | 'voided' | 'expired';
+
+/**
+ * Email history for one recipient — every notification actually sent to them.
+ * CC notifications are excluded; a CC address is not a signer.
+ */
+export interface RecipientDelivery {
+  /** First email of any kind to this recipient; null if they have never been emailed. */
+  firstSentOn: string | null;
+  /** Most recent email of any kind to this recipient. */
+  lastSentOn: string | null;
+  /** Total emails sent (request, resends, reminders, warnings, terminal notices). */
+  totalSent: number;
+  reminderCount: number;
+  lastRemindedAt: string | null;
+  warningCount: number;
+  lastWarningAt: string | null;
+}
+
 /** Where a single recipient is in the signing process. */
 export interface RecipientSignatureStatus {
   id: string;
   name: string;
   email: string;
-  /** One of 'pending', 'viewed', 'completed'. */
+  /** Raw database status — only ever 'pending', 'viewed' or 'completed'. */
   status: string;
+  /**
+   * Raw status with the document's terminal state layered on. Use this for display: a
+   * signer on a voided document reads 'voided' here but still 'pending' in `status`.
+   * A completed signature is never revoked.
+   */
+  effectiveStatus: RecipientEffectiveStatus;
   /** ISO timestamp when this recipient signed; null while pending or viewed. */
   signedOn: string | null;
   signingOrder: number;
+  delivery: RecipientDelivery;
 }
 
-/** Roll-up of the roster, so callers can answer "how many are left" without looping. */
+/** Roll-up of the roster by effective status, so callers can skip the loop. */
 export interface RecipientStatusSummary {
   total: number;
   pending: number;
   viewed: number;
   completed: number;
+  /** Signers stranded by a voided document. */
+  voided: number;
+  /** Signers stranded by an expired document. */
+  expired: number;
+  /** Recipients who can still act (pending + viewed). Zero once the document is terminal. */
+  waitingOn: number;
 }
 
 /** The identity that sent a document for signature. */
@@ -150,6 +187,8 @@ export interface DocumentRecipientsResponse {
      */
     status: string;
     createdOn: string;
+    /** When the document was dispatched to recipients; null while it is still a draft. */
+    sentOn: string | null;
     /** When the signing window closes; null when the document never expires. */
     expiresAt: string | null;
     /** Who sent it — never the synthetic API service account. */

--- a/packages/js-sdk/src/types/sign.ts
+++ b/packages/js-sdk/src/types/sign.ts
@@ -113,6 +113,52 @@ export interface DocumentStatusResponse {
   status: string;
 }
 
+/** Where a single recipient is in the signing process. */
+export interface RecipientSignatureStatus {
+  id: string;
+  name: string;
+  email: string;
+  /** One of 'pending', 'viewed', 'completed'. */
+  status: string;
+  /** ISO timestamp when this recipient signed; null while pending or viewed. */
+  signedOn: string | null;
+  signingOrder: number;
+}
+
+/** Roll-up of the roster, so callers can answer "how many are left" without looping. */
+export interface RecipientStatusSummary {
+  total: number;
+  pending: number;
+  viewed: number;
+  completed: number;
+}
+
+/** The identity that sent a document for signature. */
+export interface DocumentSender {
+  name: string;
+  email: string;
+}
+
+export interface DocumentRecipientsResponse {
+  document: {
+    id: string;
+    name: string;
+    /**
+     * Document-level status. There is no per-recipient declined/expired/voided state, so on a
+     * voided or expired document every unsigned recipient still reads 'pending' — read this to
+     * tell "still waiting" apart from "this document is dead".
+     */
+    status: string;
+    createdOn: string;
+    /** When the signing window closes; null when the document never expires. */
+    expiresAt: string | null;
+    /** Who sent it — never the synthetic API service account. */
+    sentBy: DocumentSender;
+  };
+  recipients: RecipientSignatureStatus[];
+  summary: RecipientStatusSummary;
+}
+
 // ============================================
 // SINGLE-STEP OPERATION TYPES
 // ============================================

--- a/packages/js-sdk/tests/turbosign.test.ts
+++ b/packages/js-sdk/tests/turbosign.test.ts
@@ -437,6 +437,7 @@ describe("TurboSign Module", () => {
         name: "Mutual NDA",
         status: "under_review",
         createdOn: "2026-01-01T00:00:00.000Z",
+        sentOn: "2026-01-02T08:59:00.000Z",
         expiresAt: null,
         sentBy: { name: "Jane Sender", email: "jane@acme.com" },
       },
@@ -446,19 +447,50 @@ describe("TurboSign Module", () => {
           name: "John Signer",
           email: "john@example.com",
           status: "completed",
+          effectiveStatus: "completed",
           signedOn: "2026-02-01T10:00:00.000Z",
           signingOrder: 1,
+          delivery: {
+            firstSentOn: "2026-01-02T09:00:00.000Z",
+            lastSentOn: "2026-01-09T09:00:00.000Z",
+            totalSent: 3,
+            reminderCount: 1,
+            lastRemindedAt: "2026-01-09T09:00:00.000Z",
+            warningCount: 0,
+            lastWarningAt: null,
+          },
         },
         {
           id: "rec-2",
           name: "Ada Signer",
           email: "ada@example.com",
           status: "pending",
+          effectiveStatus: "pending",
           signedOn: null,
           signingOrder: 2,
+          delivery: {
+            firstSentOn: "2026-01-02T09:00:00.000Z",
+            lastSentOn: "2026-01-02T09:00:00.000Z",
+            totalSent: 1,
+            reminderCount: 0,
+            lastRemindedAt: null,
+            warningCount: 0,
+            lastWarningAt: null,
+          },
         },
       ],
-      summary: { total: 2, pending: 1, viewed: 0, completed: 1 },
+      summary: { total: 2, pending: 1, viewed: 0, completed: 1, voided: 0, expired: 0, waitingOn: 1 },
+    };
+
+    // A voided document: the unsigned signer is stranded, the signed one keeps their signature.
+    const mockVoidedRecipientsResponse = {
+      ...mockRecipientsResponse,
+      document: { ...mockRecipientsResponse.document, status: "voided" },
+      recipients: [
+        { ...mockRecipientsResponse.recipients[0] },
+        { ...mockRecipientsResponse.recipients[1], effectiveStatus: "voided" },
+      ],
+      summary: { total: 2, pending: 0, viewed: 0, completed: 1, voided: 1, expired: 0, waitingOn: 0 },
     };
 
     it("should get every recipient with their signing status", async () => {
@@ -471,6 +503,7 @@ describe("TurboSign Module", () => {
 
       expect(result.recipients).toHaveLength(2);
       expect(result.recipients[0].status).toBe("completed");
+      expect(result.recipients[0].effectiveStatus).toBe("completed");
       expect(result.recipients[0].email).toBe("john@example.com");
       expect(result.recipients[0].signedOn).toBe("2026-02-01T10:00:00.000Z");
       expect(result.recipients[0].signingOrder).toBe(1);
@@ -496,12 +529,54 @@ describe("TurboSign Module", () => {
       });
       // Document status distinguishes a voided/expired doc from one still waiting
       expect(result.document.status).toBe("under_review");
+      expect(result.document.sentOn).toBe("2026-01-02T08:59:00.000Z");
       expect(result.summary).toEqual({
         total: 2,
         pending: 1,
         viewed: 0,
         completed: 1,
+        voided: 0,
+        expired: 0,
+        waitingOn: 1,
       });
+    });
+
+    it("should report each recipient's email history", async () => {
+      MockedHttpClient.prototype.get = jest
+        .fn()
+        .mockResolvedValue(mockRecipientsResponse);
+      TurboSign.configure({ apiKey: "test-key" });
+
+      const result = await TurboSign.getRecipients("doc-123");
+
+      expect(result.recipients[0].delivery.totalSent).toBe(3);
+      expect(result.recipients[0].delivery.firstSentOn).toBe(
+        "2026-01-02T09:00:00.000Z"
+      );
+      expect(result.recipients[0].delivery.lastSentOn).toBe(
+        "2026-01-09T09:00:00.000Z"
+      );
+      expect(result.recipients[0].delivery.reminderCount).toBe(1);
+      // A recipient emailed once has matching first/last and no reminders
+      expect(result.recipients[1].delivery.totalSent).toBe(1);
+      expect(result.recipients[1].delivery.lastRemindedAt).toBeNull();
+    });
+
+    it("should surface voided as an effective status without revoking a signature", async () => {
+      MockedHttpClient.prototype.get = jest
+        .fn()
+        .mockResolvedValue(mockVoidedRecipientsResponse);
+      TurboSign.configure({ apiKey: "test-key" });
+
+      const result = await TurboSign.getRecipients("doc-123");
+
+      // Someone who signed still signed — voiding the document does not undo it
+      expect(result.recipients[0].effectiveStatus).toBe("completed");
+      // The unsigned signer is stranded, though the raw DB status is still "pending"
+      expect(result.recipients[1].status).toBe("pending");
+      expect(result.recipients[1].effectiveStatus).toBe("voided");
+      expect(result.summary.voided).toBe(1);
+      expect(result.summary.waitingOn).toBe(0);
     });
 
     it("should propagate NotFoundError for an unknown document", async () => {

--- a/packages/js-sdk/tests/turbosign.test.ts
+++ b/packages/js-sdk/tests/turbosign.test.ts
@@ -473,7 +473,8 @@ describe("TurboSign Module", () => {
             lastSentOn: "2026-01-02T09:00:00.000Z",
             totalSent: 1,
             reminderCount: 0,
-            lastRemindedAt: null,
+            // Stamped by the initial send — NOT evidence of a reminder.
+            lastRemindedAt: "2026-01-02T09:00:00.000Z",
             warningCount: 0,
             lastWarningAt: null,
           },
@@ -558,8 +559,14 @@ describe("TurboSign Module", () => {
       );
       expect(result.recipients[0].delivery.reminderCount).toBe(1);
       // A recipient emailed once has matching first/last and no reminders
+      // Emailed once and never reminded: reminderCount stays 0, but lastRemindedAt is
+      // NOT null — the initial send stamps it as the reminder cadence clock. Asserting
+      // null here would enshrine the exact misreading the field docs warn about.
       expect(result.recipients[1].delivery.totalSent).toBe(1);
-      expect(result.recipients[1].delivery.lastRemindedAt).toBeNull();
+      expect(result.recipients[1].delivery.reminderCount).toBe(0);
+      expect(result.recipients[1].delivery.lastRemindedAt).toBe(
+        result.recipients[1].delivery.firstSentOn,
+      );
     });
 
     it("should surface voided as an effective status without revoking a signature", async () => {

--- a/packages/js-sdk/tests/turbosign.test.ts
+++ b/packages/js-sdk/tests/turbosign.test.ts
@@ -13,7 +13,7 @@
 
 import { TurboSign } from "../src/modules/sign";
 import { HttpClient } from "../src/http";
-import { NetworkError } from "../src/utils/errors";
+import { NetworkError, NotFoundError } from "../src/utils/errors";
 import type { Recipient, Field } from "../src/types/sign";
 
 // Mock the HttpClient
@@ -425,6 +425,94 @@ describe("TurboSign Module", () => {
       expect(result.status).toBe("under_review");
       expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
         "/turbosign/documents/doc-123/status"
+      );
+    });
+  });
+
+  describe("getRecipients", () => {
+    // The wire shape after the HTTP client unwraps {data: ...}
+    const mockRecipientsResponse = {
+      document: {
+        id: "doc-123",
+        name: "Mutual NDA",
+        status: "under_review",
+        createdOn: "2026-01-01T00:00:00.000Z",
+        expiresAt: null,
+        sentBy: { name: "Jane Sender", email: "jane@acme.com" },
+      },
+      recipients: [
+        {
+          id: "rec-1",
+          name: "John Signer",
+          email: "john@example.com",
+          status: "completed",
+          signedOn: "2026-02-01T10:00:00.000Z",
+          signingOrder: 1,
+        },
+        {
+          id: "rec-2",
+          name: "Ada Signer",
+          email: "ada@example.com",
+          status: "pending",
+          signedOn: null,
+          signingOrder: 2,
+        },
+      ],
+      summary: { total: 2, pending: 1, viewed: 0, completed: 1 },
+    };
+
+    it("should get every recipient with their signing status", async () => {
+      MockedHttpClient.prototype.get = jest
+        .fn()
+        .mockResolvedValue(mockRecipientsResponse);
+      TurboSign.configure({ apiKey: "test-key" });
+
+      const result = await TurboSign.getRecipients("doc-123");
+
+      expect(result.recipients).toHaveLength(2);
+      expect(result.recipients[0].status).toBe("completed");
+      expect(result.recipients[0].email).toBe("john@example.com");
+      expect(result.recipients[0].signedOn).toBe("2026-02-01T10:00:00.000Z");
+      expect(result.recipients[0].signingOrder).toBe(1);
+      // A pending signer has no signedOn timestamp
+      expect(result.recipients[1].status).toBe("pending");
+      expect(result.recipients[1].signedOn).toBeNull();
+      expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+        "/turbosign/documents/doc-123/recipients"
+      );
+    });
+
+    it("should expose who sent the document and the pending/completed roll-up", async () => {
+      MockedHttpClient.prototype.get = jest
+        .fn()
+        .mockResolvedValue(mockRecipientsResponse);
+      TurboSign.configure({ apiKey: "test-key" });
+
+      const result = await TurboSign.getRecipients("doc-123");
+
+      expect(result.document.sentBy).toEqual({
+        name: "Jane Sender",
+        email: "jane@acme.com",
+      });
+      // Document status distinguishes a voided/expired doc from one still waiting
+      expect(result.document.status).toBe("under_review");
+      expect(result.summary).toEqual({
+        total: 2,
+        pending: 1,
+        viewed: 0,
+        completed: 1,
+      });
+    });
+
+    it("should propagate NotFoundError for an unknown document", async () => {
+      const notFound = new NotFoundError("Document not found");
+      MockedHttpClient.prototype.get = jest
+        .fn()
+        .mockRejectedValue(notFound);
+      TurboSign.configure({ apiKey: "test-key" });
+
+      await expect(TurboSign.getRecipients("missing-doc")).rejects.toThrow(
+        NotFoundError
       );
     });
   });

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -280,10 +280,16 @@ $result = TurboSign::sendSignature(
     )
 );
 
-// Recipients (with their sign URLs) come back on the send result itself
-foreach ($result->recipients as $recipient) {
-    echo "{$recipient->name}: {$recipient->signUrl}\n";
+// The created recipients come back on the send result itself, as a plain array of
+// associative arrays (not objects). Each carries id, name and email.
+if ($result->recipients !== null) {
+    foreach ($result->recipients as $recipient) {
+        echo "{$recipient['name']} <{$recipient['email']}> — {$recipient['id']}\n";
+    }
 }
+
+// For signing progress afterwards, use getRecipients():
+$progress = TurboSign::getRecipients($result->documentId);
 ```
 
 #### `getStatus()`

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -289,22 +289,38 @@ foreach ($status->recipients as $recipient) {
 
 #### `getStatus()`
 
-Check the current status of a document.
+Check the document-level status. For per-recipient detail, use `getRecipients()`.
 
 ```php
 $status = TurboSign::getStatus('doc-uuid-here');
 
-echo "Document Status: {$status->status->value}\n";  // 'pending', 'completed', 'voided'
-echo "Recipients:\n";
+echo "Document Status: {$status->status}\n";  // 'under_review', 'completed', 'voided', ...
+```
 
-// Check individual recipient status
-foreach ($status->recipients as $recipient) {
-    echo "  {$recipient->name}: {$recipient->status->value}\n";
-    if ($recipient->signedAt) {
-        echo "    Signed at: {$recipient->signedAt}\n";
+#### `getRecipients()`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```php
+$result = TurboSign::getRecipients('doc-uuid-here');
+
+echo "Sent by {$result->document->sentBy->name} <{$result->document->sentBy->email}>\n";
+echo "{$result->summary->completed} of {$result->summary->total} signed, ";
+echo "{$result->summary->pending} not started\n";
+
+foreach ($result->recipients as $recipient) {
+    // 'pending' | 'viewed' | 'completed'
+    echo "  {$recipient->name} <{$recipient->email}>: {$recipient->status}\n";
+    if ($recipient->signedOn !== null) {
+        echo "    Signed on: {$recipient->signedOn}\n";
     }
 }
 ```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `$result->document->status` before treating
+> someone as "still to sign".
 
 #### `download()`
 

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -343,6 +343,15 @@ the document is terminal.
 request, resends, reminders, expiry warnings and terminal notices. CC notifications are
 excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `reminderCount` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `totalSent`. So it can read `0` while reminder emails have genuinely been sent. |
+| `lastRemindedAt` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `lastRemindedAt` alongside `reminderCount` of `0`. |
+
+`warningCount` and `lastWarningAt` are touched only by an expiry warning.
+
 #### `download()`
 
 Download the signed PDF document.

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -280,9 +280,8 @@ $result = TurboSign::sendSignature(
     )
 );
 
-// Get recipient sign URLs
-$status = TurboSign::getStatus($result->documentId);
-foreach ($status->recipients as $recipient) {
+// Recipients (with their sign URLs) come back on the send result itself
+foreach ($result->recipients as $recipient) {
     echo "{$recipient->name}: {$recipient->signUrl}\n";
 }
 ```
@@ -306,21 +305,37 @@ $result = TurboSign::getRecipients('doc-uuid-here');
 
 echo "Sent by {$result->document->sentBy->name} <{$result->document->sentBy->email}>\n";
 echo "{$result->summary->completed} of {$result->summary->total} signed, ";
-echo "{$result->summary->pending} not started\n";
+echo "still waiting on {$result->summary->waitingOn}\n";
 
 foreach ($result->recipients as $recipient) {
-    // 'pending' | 'viewed' | 'completed'
-    echo "  {$recipient->name} <{$recipient->email}>: {$recipient->status}\n";
+    // 'pending' | 'viewed' | 'completed' | 'voided' | 'expired'
+    echo "  {$recipient->name} <{$recipient->email}>: {$recipient->effectiveStatus}\n";
     if ($recipient->signedOn !== null) {
         echo "    Signed on: {$recipient->signedOn}\n";
     }
+    echo "    Emailed {$recipient->delivery->totalSent}x\n";
 }
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `$result->document->status` before treating
-> someone as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `status` | `pending`, `viewed`, `completed` | The raw database value |
+| `effectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `status`. `effectiveStatus` layers the
+document's outcome on top — that's the one to show a user. A completed signature is never
+revoked: someone who signed before the document was voided still reads `completed`.
+
+`summary` counts by `effectiveStatus`, and `waitingOn` (pending + viewed) drops to zero once
+the document is terminal.
+
+**`delivery`** is that recipient's email history — `firstSentOn`, `lastSentOn`, `totalSent`,
+`reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt`. It counts the signature
+request, resends, reminders, expiry warnings and terminal notices. CC notifications are
+excluded, since a CC address is not a signer.
 
 #### `download()`
 

--- a/packages/php-sdk/examples/turbosign-send-simple.php
+++ b/packages/php-sdk/examples/turbosign-send-simple.php
@@ -110,17 +110,17 @@ function sendDirectlyExample(): void
         echo "Document ID: {$result->documentId}\n";
         echo "Message: {$result->message}\n";
 
-        // To get sign URLs and recipient details, use getStatus
+        // Signing links are emailed to recipients — they are not returned by the API.
+        // getRecipients reports who has signed and who you are still waiting on.
         try {
-            $status = TurboSign::getStatus($result->documentId);
-            if (!empty($status->recipients)) {
-                echo "\nSign URLs:\n";
-                foreach ($status->recipients as $recipient) {
-                    echo "  {$recipient->name}: {$recipient->signUrl}\n";
-                }
+            $progress = TurboSign::getRecipients($result->documentId);
+            echo "\n{$progress->summary->completed} of {$progress->summary->total} signed, ";
+            echo "still waiting on {$progress->summary->waitingOn}\n";
+            foreach ($progress->recipients as $recipient) {
+                echo "  {$recipient->name} <{$recipient->email}>: {$recipient->effectiveStatus}\n";
             }
         } catch (Exception $statusError) {
-            echo "\nNote: Could not fetch recipient sign URLs\n";
+            echo "\nNote: Could not fetch recipient status\n";
         }
 
     } catch (Exception $error) {

--- a/packages/php-sdk/src/TurboSign.php
+++ b/packages/php-sdk/src/TurboSign.php
@@ -10,6 +10,7 @@ use TurboDocx\Types\Requests\CreateSignatureReviewLinkRequest;
 use TurboDocx\Types\Requests\SendSignatureRequest;
 use TurboDocx\Types\Responses\AuditTrailResponse;
 use TurboDocx\Types\Responses\CreateSignatureReviewLinkResponse;
+use TurboDocx\Types\Responses\DocumentRecipientsResponse;
 use TurboDocx\Types\Responses\DocumentStatusResponse;
 use TurboDocx\Types\Responses\ResendEmailResponse;
 use TurboDocx\Types\Responses\SendSignatureResponse;
@@ -247,6 +248,29 @@ final class TurboSign
         $client = self::getClient();
         $response = $client->get("/turbosign/documents/{$documentId}/status");
         return DocumentStatusResponse::fromArray($response);
+    }
+
+    /**
+     * Get every recipient on a document with their signing status
+     *
+     * Answers "who has signed and who are we still waiting on" in one call, and reports
+     * who sent the document. The summary carries the pending/viewed/completed counts.
+     *
+     * @param string $documentId ID of the document
+     * @return DocumentRecipientsResponse
+     *
+     * @example
+     * ```php
+     * $result = TurboSign::getRecipients($documentId);
+     * echo "{$result->summary->completed}/{$result->summary->total} signed";
+     * echo "sent by {$result->document->sentBy->name}";
+     * ```
+     */
+    public static function getRecipients(string $documentId): DocumentRecipientsResponse
+    {
+        $client = self::getClient();
+        $response = $client->get("/turbosign/documents/{$documentId}/recipients");
+        return DocumentRecipientsResponse::fromArray($response);
     }
 
     /**

--- a/packages/php-sdk/src/Types/Responses/DocumentRecipientsResponse.php
+++ b/packages/php-sdk/src/Types/Responses/DocumentRecipientsResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * Response from getRecipients — every recipient on a document with their signing status,
+ * plus who sent the document and a pending/viewed/completed roll-up.
+ */
+final class DocumentRecipientsResponse
+{
+    /**
+     * @param RecipientsDocument $document
+     * @param array<RecipientSignatureStatus> $recipients
+     * @param RecipientStatusSummary $summary
+     */
+    public function __construct(
+        public RecipientsDocument $document,
+        public array $recipients,
+        public RecipientStatusSummary $summary,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        $recipients = array_map(
+            fn(array $r) => RecipientSignatureStatus::fromArray($r),
+            $data['recipients'] ?? []
+        );
+
+        return new self(
+            document: RecipientsDocument::fromArray($data['document'] ?? []),
+            recipients: $recipients,
+            summary: RecipientStatusSummary::fromArray($data['summary'] ?? []),
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/DocumentSender.php
+++ b/packages/php-sdk/src/Types/Responses/DocumentSender.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * The identity that sent a document for signature.
+ *
+ * Never the synthetic API service account — the backend resolves the real sender.
+ */
+final class DocumentSender
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            name: $data['name'] ?? '',
+            email: $data['email'] ?? '',
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/RecipientDelivery.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientDelivery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * Email history for one recipient — every notification actually sent to them.
+ *
+ * CC notifications are excluded; a CC address is not a signer.
+ */
+final class RecipientDelivery
+{
+    /**
+     * @param string|null $firstSentOn First email of any kind; null if never emailed.
+     * @param string|null $lastSentOn Most recent email of any kind.
+     * @param int $totalSent Request, resends, reminders, warnings and terminal notices.
+     */
+    public function __construct(
+        public ?string $firstSentOn,
+        public ?string $lastSentOn,
+        public int $totalSent,
+        public int $reminderCount,
+        public ?string $lastRemindedAt,
+        public int $warningCount,
+        public ?string $lastWarningAt,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            firstSentOn: $data['firstSentOn'] ?? null,
+            lastSentOn: $data['lastSentOn'] ?? null,
+            totalSent: (int) ($data['totalSent'] ?? 0),
+            reminderCount: (int) ($data['reminderCount'] ?? 0),
+            lastRemindedAt: $data['lastRemindedAt'] ?? null,
+            warningCount: (int) ($data['warningCount'] ?? 0),
+            lastWarningAt: $data['lastWarningAt'] ?? null,
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/RecipientDelivery.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientDelivery.php
@@ -15,6 +15,17 @@ final class RecipientDelivery
      * @param string|null $firstSentOn First email of any kind; null if never emailed.
      * @param string|null $lastSentOn Most recent email of any kind.
      * @param int $totalSent Request, resends, reminders, warnings and terminal notices.
+     * @param int $reminderCount Automatic (scheduled) reminders only — the counter
+     *   maxReminders caps. A manual "remind now" does NOT increment it (it must not consume
+     *   the cap budget), though it does land in $totalSent. So this can read 0 while
+     *   reminder emails have genuinely been sent.
+     * @param string|null $lastRemindedAt When the reminder cadence clock was last reset —
+     *   NOT necessarily when a reminder was sent. Stamped by the initial signature-request
+     *   send, each scheduled reminder, each manual "remind now", and each expiry warning.
+     *   Only scheduled reminders bump $reminderCount, so a freshly-sent document normally
+     *   shows a non-null value here alongside $reminderCount 0.
+     * @param int $warningCount Expiry warnings sent. Only a warning touches this.
+     * @param string|null $lastWarningAt When the last expiry warning went out.
      */
     public function __construct(
         public ?string $firstSentOn,

--- a/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
@@ -10,7 +10,11 @@ namespace TurboDocx\Types\Responses;
 final class RecipientSignatureStatus
 {
     /**
-     * @param string $status One of 'pending', 'viewed', 'completed'.
+     * @param string $status Raw database status — only ever 'pending', 'viewed' or 'completed'.
+     * @param string $effectiveStatus Raw status with the document's terminal state layered on:
+     *   'pending', 'viewed', 'completed', 'voided' or 'expired'. Use this for display — a signer
+     *   on a voided document reads 'voided' here but still 'pending' in $status. A completed
+     *   signature is never revoked.
      * @param string|null $signedOn When this recipient signed; null while pending or viewed.
      */
     public function __construct(
@@ -18,8 +22,10 @@ final class RecipientSignatureStatus
         public string $name,
         public string $email,
         public string $status,
+        public string $effectiveStatus,
         public ?string $signedOn,
         public int $signingOrder,
+        public RecipientDelivery $delivery,
     ) {}
 
     /**
@@ -35,8 +41,10 @@ final class RecipientSignatureStatus
             name: $data['name'] ?? '',
             email: $data['email'] ?? '',
             status: $data['status'] ?? '',
+            effectiveStatus: $data['effectiveStatus'] ?? ($data['status'] ?? ''),
             signedOn: $data['signedOn'] ?? null,
             signingOrder: (int) ($data['signingOrder'] ?? 0),
+            delivery: RecipientDelivery::fromArray($data['delivery'] ?? []),
         );
     }
 }

--- a/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
@@ -41,7 +41,12 @@ final class RecipientSignatureStatus
             name: $data['name'] ?? '',
             email: $data['email'] ?? '',
             status: $data['status'] ?? '',
-            effectiveStatus: $data['effectiveStatus'] ?? ($data['status'] ?? ''),
+            // Never fall back to `status` here. The two fields are deliberately different
+            // — on a voided document a stranded signer reads "voided" in effectiveStatus
+            // but still "pending" in status. Substituting one for the other would make a
+            // backend regression that stops emitting effectiveStatus invisible in PHP
+            // while it is visible in the other five SDKs.
+            effectiveStatus: $data['effectiveStatus'] ?? '',
             signedOn: $data['signedOn'] ?? null,
             signingOrder: (int) ($data['signingOrder'] ?? 0),
             delivery: RecipientDelivery::fromArray($data['delivery'] ?? []),

--- a/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientSignatureStatus.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * Where a single recipient is in the signing process.
+ */
+final class RecipientSignatureStatus
+{
+    /**
+     * @param string $status One of 'pending', 'viewed', 'completed'.
+     * @param string|null $signedOn When this recipient signed; null while pending or viewed.
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $email,
+        public string $status,
+        public ?string $signedOn,
+        public int $signingOrder,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            email: $data['email'] ?? '',
+            status: $data['status'] ?? '',
+            signedOn: $data['signedOn'] ?? null,
+            signingOrder: (int) ($data['signingOrder'] ?? 0),
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/RecipientStatusSummary.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientStatusSummary.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * Roll-up of a document's roster, so callers can answer
+ * "how many are we waiting on" without looping.
+ */
+final class RecipientStatusSummary
+{
+    public function __construct(
+        public int $total,
+        public int $pending,
+        public int $viewed,
+        public int $completed,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            total: (int) ($data['total'] ?? 0),
+            pending: (int) ($data['pending'] ?? 0),
+            viewed: (int) ($data['viewed'] ?? 0),
+            completed: (int) ($data['completed'] ?? 0),
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/RecipientStatusSummary.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientStatusSummary.php
@@ -10,11 +10,20 @@ namespace TurboDocx\Types\Responses;
  */
 final class RecipientStatusSummary
 {
+    /**
+     * @param int $voided Signers stranded by a voided document.
+     * @param int $expired Signers stranded by an expired document.
+     * @param int $waitingOn Recipients who can still act (pending + viewed);
+     *   zero once the document is terminal.
+     */
     public function __construct(
         public int $total,
         public int $pending,
         public int $viewed,
         public int $completed,
+        public int $voided,
+        public int $expired,
+        public int $waitingOn,
     ) {}
 
     /**
@@ -30,6 +39,9 @@ final class RecipientStatusSummary
             pending: (int) ($data['pending'] ?? 0),
             viewed: (int) ($data['viewed'] ?? 0),
             completed: (int) ($data['completed'] ?? 0),
+            voided: (int) ($data['voided'] ?? 0),
+            expired: (int) ($data['expired'] ?? 0),
+            waitingOn: (int) ($data['waitingOn'] ?? 0),
         );
     }
 }

--- a/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
@@ -10,10 +10,11 @@ namespace TurboDocx\Types\Responses;
 final class RecipientsDocument
 {
     /**
-     * @param string $status Document-level status. There is no per-recipient
-     *   declined/expired/voided state, so on a voided or expired document every unsigned
-     *   recipient still reads 'pending' — read this to tell "still waiting" apart from
-     *   "this document is dead".
+     * @param string $status Document-level status — the full SignatureDocumentStatus set
+     *   ('draft', 'under_review', 'completed', 'voided', 'expired', …). For per-recipient
+     *   display you do not need to overlay this yourself: each RecipientSignatureStatus
+     *   already carries $effectiveStatus, the raw recipient status with this
+     *   document-level outcome layered on.
      * @param string|null $sentOn When the document went out to recipients; null while a draft.
      * @param string|null $expiresAt When the signing window closes; null if it never expires.
      */

--- a/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses;
+
+/**
+ * The document a set of recipients belongs to, as returned by getRecipients.
+ */
+final class RecipientsDocument
+{
+    /**
+     * @param string $status Document-level status. There is no per-recipient
+     *   declined/expired/voided state, so on a voided or expired document every unsigned
+     *   recipient still reads 'pending' — read this to tell "still waiting" apart from
+     *   "this document is dead".
+     * @param string|null $expiresAt When the signing window closes; null if it never expires.
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $status,
+        public string $createdOn,
+        public ?string $expiresAt,
+        public DocumentSender $sentBy,
+    ) {}
+
+    /**
+     * Create from array
+     *
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'] ?? '',
+            name: $data['name'] ?? '',
+            status: $data['status'] ?? '',
+            createdOn: $data['createdOn'] ?? '',
+            expiresAt: $data['expiresAt'] ?? null,
+            sentBy: DocumentSender::fromArray($data['sentBy'] ?? []),
+        );
+    }
+}

--- a/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
+++ b/packages/php-sdk/src/Types/Responses/RecipientsDocument.php
@@ -14,6 +14,7 @@ final class RecipientsDocument
      *   declined/expired/voided state, so on a voided or expired document every unsigned
      *   recipient still reads 'pending' — read this to tell "still waiting" apart from
      *   "this document is dead".
+     * @param string|null $sentOn When the document went out to recipients; null while a draft.
      * @param string|null $expiresAt When the signing window closes; null if it never expires.
      */
     public function __construct(
@@ -21,6 +22,7 @@ final class RecipientsDocument
         public string $name,
         public string $status,
         public string $createdOn,
+        public ?string $sentOn,
         public ?string $expiresAt,
         public DocumentSender $sentBy,
     ) {}
@@ -38,6 +40,7 @@ final class RecipientsDocument
             name: $data['name'] ?? '',
             status: $data['status'] ?? '',
             createdOn: $data['createdOn'] ?? '',
+            sentOn: $data['sentOn'] ?? null,
             expiresAt: $data['expiresAt'] ?? null,
             sentBy: DocumentSender::fromArray($data['sentBy'] ?? []),
         );

--- a/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
+++ b/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
@@ -63,7 +63,8 @@ final class DocumentRecipientsResponseTest extends TestCase
                         'lastSentOn' => '2026-01-02T09:00:00.000Z',
                         'totalSent' => 1,
                         'reminderCount' => 0,
-                        'lastRemindedAt' => null,
+                        // Stamped by the initial send — NOT evidence of a reminder.
+                        'lastRemindedAt' => '2026-01-02T09:00:00.000Z',
                         'warningCount' => 0,
                         'lastWarningAt' => null,
                     ],
@@ -85,9 +86,12 @@ final class DocumentRecipientsResponseTest extends TestCase
         $this->assertSame('2026-01-02T09:00:00.000Z', $chased->firstSentOn);
         $this->assertSame('2026-01-09T09:00:00.000Z', $chased->lastSentOn);
         $this->assertSame(1, $chased->reminderCount);
-        // A recipient emailed once has no reminders
-        $this->assertSame(1, $result->recipients[1]->delivery->totalSent);
-        $this->assertNull($result->recipients[1]->delivery->lastRemindedAt);
+        // Emailed once and never reminded: reminderCount stays 0, but lastRemindedAt is
+        // NOT null — the initial send stamps it as the reminder cadence clock.
+        $once = $result->recipients[1]->delivery;
+        $this->assertSame(1, $once->totalSent);
+        $this->assertSame(0, $once->reminderCount);
+        $this->assertSame($once->firstSentOn, $once->lastRemindedAt);
     }
 
     public function testSurfacesVoidedEffectiveStatusWithoutRevokingASignature(): void

--- a/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
+++ b/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
@@ -27,6 +27,7 @@ final class DocumentRecipientsResponseTest extends TestCase
                 'name' => 'Mutual NDA',
                 'status' => 'under_review',
                 'createdOn' => '2026-01-01T00:00:00.000Z',
+                'sentOn' => '2026-01-02T08:59:00.000Z',
                 'expiresAt' => null,
                 'sentBy' => ['name' => 'Jane Sender', 'email' => 'jane@acme.com'],
             ],
@@ -36,20 +37,85 @@ final class DocumentRecipientsResponseTest extends TestCase
                     'name' => 'John Signer',
                     'email' => 'john@example.com',
                     'status' => 'completed',
+                    'effectiveStatus' => 'completed',
                     'signedOn' => '2026-02-01T10:00:00.000Z',
                     'signingOrder' => 1,
+                    'delivery' => [
+                        'firstSentOn' => '2026-01-02T09:00:00.000Z',
+                        'lastSentOn' => '2026-01-09T09:00:00.000Z',
+                        'totalSent' => 3,
+                        'reminderCount' => 1,
+                        'lastRemindedAt' => '2026-01-09T09:00:00.000Z',
+                        'warningCount' => 0,
+                        'lastWarningAt' => null,
+                    ],
                 ],
                 [
                     'id' => 'rec-2',
                     'name' => 'Ada Signer',
                     'email' => 'ada@example.com',
                     'status' => 'pending',
+                    'effectiveStatus' => 'pending',
                     'signedOn' => null,
                     'signingOrder' => 2,
+                    'delivery' => [
+                        'firstSentOn' => '2026-01-02T09:00:00.000Z',
+                        'lastSentOn' => '2026-01-02T09:00:00.000Z',
+                        'totalSent' => 1,
+                        'reminderCount' => 0,
+                        'lastRemindedAt' => null,
+                        'warningCount' => 0,
+                        'lastWarningAt' => null,
+                    ],
                 ],
             ],
-            'summary' => ['total' => 2, 'pending' => 1, 'viewed' => 0, 'completed' => 1],
+            'summary' => [
+                'total' => 2, 'pending' => 1, 'viewed' => 0, 'completed' => 1,
+                'voided' => 0, 'expired' => 0, 'waitingOn' => 1,
+            ],
         ];
+    }
+
+    public function testMapsEachRecipientsEmailHistory(): void
+    {
+        $result = DocumentRecipientsResponse::fromArray($this->wirePayload());
+
+        $chased = $result->recipients[0]->delivery;
+        $this->assertSame(3, $chased->totalSent);
+        $this->assertSame('2026-01-02T09:00:00.000Z', $chased->firstSentOn);
+        $this->assertSame('2026-01-09T09:00:00.000Z', $chased->lastSentOn);
+        $this->assertSame(1, $chased->reminderCount);
+        // A recipient emailed once has no reminders
+        $this->assertSame(1, $result->recipients[1]->delivery->totalSent);
+        $this->assertNull($result->recipients[1]->delivery->lastRemindedAt);
+    }
+
+    public function testSurfacesVoidedEffectiveStatusWithoutRevokingASignature(): void
+    {
+        $payload = $this->wirePayload();
+        $payload['document']['status'] = 'voided';
+        $payload['recipients'][1]['effectiveStatus'] = 'voided';
+        $payload['summary'] = [
+            'total' => 2, 'pending' => 0, 'viewed' => 0, 'completed' => 1,
+            'voided' => 1, 'expired' => 0, 'waitingOn' => 0,
+        ];
+
+        $result = DocumentRecipientsResponse::fromArray($payload);
+
+        // Someone who signed still signed — voiding the document does not undo it
+        $this->assertSame('completed', $result->recipients[0]->effectiveStatus);
+        // The unsigned signer is stranded, though the raw DB status is still 'pending'
+        $this->assertSame('pending', $result->recipients[1]->status);
+        $this->assertSame('voided', $result->recipients[1]->effectiveStatus);
+        $this->assertSame(1, $result->summary->voided);
+        $this->assertSame(0, $result->summary->waitingOn);
+    }
+
+    public function testDocumentReportsWhenItWasSent(): void
+    {
+        $result = DocumentRecipientsResponse::fromArray($this->wirePayload());
+
+        $this->assertSame('2026-01-02T08:59:00.000Z', $result->document->sentOn);
     }
 
     public function testMapsEveryRecipientWithTheirSigningStatus(): void
@@ -78,13 +144,19 @@ final class DocumentRecipientsResponseTest extends TestCase
         $this->assertSame(1, $result->summary->pending);
         $this->assertSame(0, $result->summary->viewed);
         $this->assertSame(1, $result->summary->completed);
+        $this->assertSame(0, $result->summary->voided);
+        $this->assertSame(0, $result->summary->expired);
+        $this->assertSame(1, $result->summary->waitingOn);
     }
 
     public function testHandlesADocumentWithNoRecipients(): void
     {
         $payload = $this->wirePayload();
         $payload['recipients'] = [];
-        $payload['summary'] = ['total' => 0, 'pending' => 0, 'viewed' => 0, 'completed' => 0];
+        $payload['summary'] = [
+            'total' => 0, 'pending' => 0, 'viewed' => 0, 'completed' => 0,
+            'voided' => 0, 'expired' => 0, 'waitingOn' => 0,
+        ];
 
         $result = DocumentRecipientsResponse::fromArray($payload);
 

--- a/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
+++ b/packages/php-sdk/tests/Unit/DocumentRecipientsResponseTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use TurboDocx\Types\Responses\DocumentRecipientsResponse;
+
+/**
+ * Tests for the getRecipients response types.
+ *
+ * The PHP SDK convention (per existing tests) is to cover config + types rather than
+ * full HTTP mocking, so these exercise fromArray() against the exact wire shape the
+ * backend returns after the HTTP client unwraps the {data: ...} envelope.
+ */
+final class DocumentRecipientsResponseTest extends TestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private function wirePayload(): array
+    {
+        return [
+            'document' => [
+                'id' => 'doc-123',
+                'name' => 'Mutual NDA',
+                'status' => 'under_review',
+                'createdOn' => '2026-01-01T00:00:00.000Z',
+                'expiresAt' => null,
+                'sentBy' => ['name' => 'Jane Sender', 'email' => 'jane@acme.com'],
+            ],
+            'recipients' => [
+                [
+                    'id' => 'rec-1',
+                    'name' => 'John Signer',
+                    'email' => 'john@example.com',
+                    'status' => 'completed',
+                    'signedOn' => '2026-02-01T10:00:00.000Z',
+                    'signingOrder' => 1,
+                ],
+                [
+                    'id' => 'rec-2',
+                    'name' => 'Ada Signer',
+                    'email' => 'ada@example.com',
+                    'status' => 'pending',
+                    'signedOn' => null,
+                    'signingOrder' => 2,
+                ],
+            ],
+            'summary' => ['total' => 2, 'pending' => 1, 'viewed' => 0, 'completed' => 1],
+        ];
+    }
+
+    public function testMapsEveryRecipientWithTheirSigningStatus(): void
+    {
+        $result = DocumentRecipientsResponse::fromArray($this->wirePayload());
+
+        $this->assertCount(2, $result->recipients);
+        $this->assertSame('completed', $result->recipients[0]->status);
+        $this->assertSame('john@example.com', $result->recipients[0]->email);
+        $this->assertSame('2026-02-01T10:00:00.000Z', $result->recipients[0]->signedOn);
+        $this->assertSame(1, $result->recipients[0]->signingOrder);
+        // A pending signer has no signedOn timestamp
+        $this->assertSame('pending', $result->recipients[1]->status);
+        $this->assertNull($result->recipients[1]->signedOn);
+    }
+
+    public function testExposesSenderAndSummary(): void
+    {
+        $result = DocumentRecipientsResponse::fromArray($this->wirePayload());
+
+        $this->assertSame('Jane Sender', $result->document->sentBy->name);
+        $this->assertSame('jane@acme.com', $result->document->sentBy->email);
+        // Document status distinguishes a voided/expired doc from one still waiting
+        $this->assertSame('under_review', $result->document->status);
+        $this->assertSame(2, $result->summary->total);
+        $this->assertSame(1, $result->summary->pending);
+        $this->assertSame(0, $result->summary->viewed);
+        $this->assertSame(1, $result->summary->completed);
+    }
+
+    public function testHandlesADocumentWithNoRecipients(): void
+    {
+        $payload = $this->wirePayload();
+        $payload['recipients'] = [];
+        $payload['summary'] = ['total' => 0, 'pending' => 0, 'viewed' => 0, 'completed' => 0];
+
+        $result = DocumentRecipientsResponse::fromArray($payload);
+
+        $this->assertSame([], $result->recipients);
+        $this->assertSame(0, $result->summary->total);
+    }
+}

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -287,16 +287,41 @@ for recipient in result["recipients"]:
 
 #### `get_status()`
 
-Check the current status of a document.
+Check the document-level status. For per-recipient detail, use `get_recipients()`.
 
 ```python
 status = await TurboSign.get_status("doc-uuid-here")
 
-print(f"Status: {status['status']}")  # 'pending', 'completed', 'voided'
-
-for recipient in status["recipients"]:
-    print(f"{recipient['name']}: {recipient['status']}")
+print(f"Status: {status['status']}")  # 'under_review', 'completed', 'voided', ...
 ```
+
+#### `get_recipients()`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```python
+result = await TurboSign.get_recipients("doc-uuid-here")
+
+sender = result["document"]["sentBy"]
+print(f"Sent by {sender['name']} <{sender['email']}>")
+
+summary = result["summary"]
+print(f"{summary['completed']} of {summary['total']} signed, {summary['pending']} not started")
+
+for r in result["recipients"]:
+    # 'pending' | 'viewed' | 'completed'
+    print(f"{r['name']} <{r['email']}>: {r['status']}")
+    if r["signedOn"]:
+        print(f"  signed {r['signedOn']}")
+
+# Who are we chasing?
+waiting_on = [r for r in result["recipients"] if r["status"] != "completed"]
+```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `result["document"]["status"]` before
+> treating someone as "still to sign".
 
 #### `download()`
 
@@ -857,6 +882,7 @@ The `manual_test.py` file tests all SDK methods:
 - ✅ `create_signature_review_link()` - Document upload for review
 - ✅ `send_signature()` - Send for signature
 - ✅ `get_status()` - Check document status
+- ✅ `get_recipients()` - Per-recipient signing status (who signed, who is pending)
 - ✅ `download()` - Download signed document
 - ✅ `void_document()` - Cancel signature request
 - ✅ `resend_email()` - Resend signature emails

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -344,6 +344,15 @@ the document is terminal.
 request, resends, reminders, expiry warnings and terminal notices. CC notifications are
 excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `reminderCount` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `totalSent`. So it can read `0` while reminder emails have genuinely been sent. |
+| `lastRemindedAt` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `lastRemindedAt` alongside `reminderCount` of `0`. |
+
+`warningCount` and `lastWarningAt` are touched only by an expiry warning.
+
 #### `download()`
 
 Download the signed document.

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -281,8 +281,12 @@ result = await TurboSign.send_signature(
     ]
 )
 
+# The created recipients come back on the send result — each carries id, name and email.
+# Signing links are emailed to them; they are not returned here.
 for recipient in result["recipients"]:
-    print(f"{recipient['name']}: {recipient['signUrl']}")
+    print(f"{recipient['name']} <{recipient['email']}> — {recipient['id']}")
+
+# For signing progress afterwards, use get_recipients().
 ```
 
 #### `get_status()`

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -304,24 +304,41 @@ result = await TurboSign.get_recipients("doc-uuid-here")
 
 sender = result["document"]["sentBy"]
 print(f"Sent by {sender['name']} <{sender['email']}>")
+print(f"Sent on {result['document']['sentOn'] or 'not sent yet'}")
 
 summary = result["summary"]
-print(f"{summary['completed']} of {summary['total']} signed, {summary['pending']} not started")
+print(f"{summary['completed']} of {summary['total']} signed, waiting on {summary['waitingOn']}")
 
 for r in result["recipients"]:
-    # 'pending' | 'viewed' | 'completed'
-    print(f"{r['name']} <{r['email']}>: {r['status']}")
+    # 'pending' | 'viewed' | 'completed' | 'voided' | 'expired'
+    print(f"{r['name']} <{r['email']}>: {r['effectiveStatus']}")
     if r["signedOn"]:
         print(f"  signed {r['signedOn']}")
+    print(f"  emailed {r['delivery']['totalSent']}x, last {r['delivery']['lastSentOn'] or 'never'}")
 
 # Who are we chasing?
-waiting_on = [r for r in result["recipients"] if r["status"] != "completed"]
+chasing = [r for r in result["recipients"] if r["effectiveStatus"] in ("pending", "viewed")]
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `result["document"]["status"]` before
-> treating someone as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `status` | `pending`, `viewed`, `completed` | The raw database value |
+| `effectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `status`. `effectiveStatus` layers the
+document's outcome on top — that's the one to show a user. A completed signature is never
+revoked: someone who signed before the document was voided still reads `completed`.
+
+`summary` counts by `effectiveStatus`, and `waitingOn` (pending + viewed) drops to zero once
+the document is terminal.
+
+**`delivery`** is that recipient's email history — `firstSentOn`, `lastSentOn`, `totalSent`,
+`reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt`. It counts the signature
+request, resends, reminders, expiry warnings and terminal notices. CC notifications are
+excluded, since a CC address is not a signer.
 
 #### `download()`
 

--- a/packages/py-sdk/examples/turbosign_send_simple.py
+++ b/packages/py-sdk/examples/turbosign_send_simple.py
@@ -107,15 +107,19 @@ async def send_directly_example():
         print(f"Document ID: {result['documentId']}")
         print(f"Message: {result['message']}")
 
-        # To get sign URLs and recipient details, use get_status
+        # Signing links are emailed to recipients — they are not returned by the API.
+        # get_recipients reports who has signed and who you are still waiting on.
         try:
-            status = await TurboSign.get_status(result['documentId'])
-            if status.get('recipients'):
-                print("\nSign URLs:")
-                for recipient in status['recipients']:
-                    print(f"  {recipient['name']}: {recipient.get('signUrl', 'N/A')}")
+            progress = await TurboSign.get_recipients(result['documentId'])
+            summary = progress['summary']
+            print(
+                f"\n{summary['completed']} of {summary['total']} signed, "
+                f"still waiting on {summary['waitingOn']}"
+            )
+            for recipient in progress['recipients']:
+                print(f"  {recipient['name']} <{recipient['email']}>: {recipient['effectiveStatus']}")
         except Exception as status_error:
-            print("\nNote: Could not fetch recipient sign URLs")
+            print("\nNote: Could not fetch recipient status")
 
     except Exception as error:
         print(f"Error: {error}")

--- a/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
@@ -346,20 +346,29 @@ class TurboSign:
 
         Returns:
             Dict with:
-                - document: id, name, status, createdOn, expiresAt, and
-                  sentBy {name, email} — who sent it
-                - recipients: list of {id, name, email, status, signedOn, signingOrder}
-                  where status is 'pending', 'viewed' or 'completed'
-                - summary: {total, pending, viewed, completed}
+                - document: id, name, status, createdOn, sentOn (null while a draft),
+                  expiresAt, and sentBy {name, email} — who sent it
+                - recipients: list of {id, name, email, status, effectiveStatus, signedOn,
+                  signingOrder, delivery}
+                - summary: {total, pending, viewed, completed, voided, expired, waitingOn}
 
-            There is no per-recipient declined/expired/voided state, so on a voided or
-            expired document every unsigned recipient still reads 'pending' — read
-            document['status'] to tell "still waiting" apart from "this document is dead".
+            `status` is the raw database value and is only ever 'pending', 'viewed' or
+            'completed'. `effectiveStatus` layers the document's terminal state on top and
+            is what you should display: a signer on a voided or expired document reads
+            'voided'/'expired' there while `status` still says 'pending'. A completed
+            signature is never revoked.
+
+            `delivery` is that recipient's email history:
+            {firstSentOn, lastSentOn, totalSent, reminderCount, lastRemindedAt,
+            warningCount, lastWarningAt}. CC notifications are excluded — a CC address
+            is not a signer.
 
         Example:
             >>> result = await TurboSign.get_recipients("doc-123")
             >>> print(f"{result['summary']['completed']}/{result['summary']['total']} signed")
-            >>> waiting = [r for r in result["recipients"] if r["status"] != "completed"]
+            >>> print(f"still waiting on {result['summary']['waitingOn']}")
+            >>> for r in result["recipients"]:
+            ...     print(r["name"], r["effectiveStatus"], r["delivery"]["totalSent"])
         """
         client = cls._get_client()
         return await client.get(f"/turbosign/documents/{document_id}/recipients")

--- a/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
@@ -363,6 +363,20 @@ class TurboSign:
             warningCount, lastWarningAt}. CC notifications are excluded — a CC address
             is not a signer.
 
+            Two `delivery` fields are easy to misread:
+
+            - `reminderCount` counts AUTOMATIC (scheduled) reminders only — it is the
+              counter `maxReminders` caps. A manual "remind now" does not increment it
+              (it must not consume the cap budget), though it does land in `totalSent`.
+              So it can read 0 while reminder emails have genuinely been sent.
+            - `lastRemindedAt` is when the reminder CADENCE CLOCK was last reset, not
+              necessarily when a reminder was sent. The initial signature-request send,
+              each scheduled reminder, each manual "remind now" and each expiry warning
+              all stamp it. A freshly-sent document therefore normally reads a non-null
+              `lastRemindedAt` alongside `reminderCount` of 0.
+
+            `warningCount` / `lastWarningAt` are touched only by an expiry warning.
+
         Example:
             >>> result = await TurboSign.get_recipients("doc-123")
             >>> print(f"{result['summary']['completed']}/{result['summary']['total']} signed")

--- a/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/sign.py
@@ -334,6 +334,37 @@ class TurboSign:
         return await client.get(f"/turbosign/documents/{document_id}/status")
 
     @classmethod
+    async def get_recipients(cls, document_id: str) -> Dict[str, Any]:
+        """
+        Get every recipient on a document with their signing status
+
+        Answers "who has signed and who are we still waiting on" in one call, and
+        reports who sent the document.
+
+        Args:
+            document_id: ID of the document
+
+        Returns:
+            Dict with:
+                - document: id, name, status, createdOn, expiresAt, and
+                  sentBy {name, email} — who sent it
+                - recipients: list of {id, name, email, status, signedOn, signingOrder}
+                  where status is 'pending', 'viewed' or 'completed'
+                - summary: {total, pending, viewed, completed}
+
+            There is no per-recipient declined/expired/voided state, so on a voided or
+            expired document every unsigned recipient still reads 'pending' — read
+            document['status'] to tell "still waiting" apart from "this document is dead".
+
+        Example:
+            >>> result = await TurboSign.get_recipients("doc-123")
+            >>> print(f"{result['summary']['completed']}/{result['summary']['total']} signed")
+            >>> waiting = [r for r in result["recipients"] if r["status"] != "completed"]
+        """
+        client = cls._get_client()
+        return await client.get(f"/turbosign/documents/{document_id}/recipients")
+
+    @classmethod
     async def download(cls, document_id: str) -> bytes:
         """
         Download the signed document

--- a/packages/py-sdk/tests/test_turbosign.py
+++ b/packages/py-sdk/tests/test_turbosign.py
@@ -339,6 +339,7 @@ class TestGetRecipients:
                 "name": "Mutual NDA",
                 "status": "under_review",
                 "createdOn": "2026-01-01T00:00:00.000Z",
+                "sentOn": "2026-01-02T08:59:00.000Z",
                 "expiresAt": None,
                 "sentBy": {"name": "Jane Sender", "email": "jane@acme.com"},
             },
@@ -348,20 +349,94 @@ class TestGetRecipients:
                     "name": "John Signer",
                     "email": "john@example.com",
                     "status": "completed",
+                    "effectiveStatus": "completed",
                     "signedOn": "2026-02-01T10:00:00.000Z",
                     "signingOrder": 1,
+                    "delivery": {
+                        "firstSentOn": "2026-01-02T09:00:00.000Z",
+                        "lastSentOn": "2026-01-09T09:00:00.000Z",
+                        "totalSent": 3,
+                        "reminderCount": 1,
+                        "lastRemindedAt": "2026-01-09T09:00:00.000Z",
+                        "warningCount": 0,
+                        "lastWarningAt": None,
+                    },
                 },
                 {
                     "id": "rec-2",
                     "name": "Ada Signer",
                     "email": "ada@example.com",
                     "status": "pending",
+                    "effectiveStatus": "pending",
                     "signedOn": None,
                     "signingOrder": 2,
+                    "delivery": {
+                        "firstSentOn": "2026-01-02T09:00:00.000Z",
+                        "lastSentOn": "2026-01-02T09:00:00.000Z",
+                        "totalSent": 1,
+                        "reminderCount": 0,
+                        "lastRemindedAt": None,
+                        "warningCount": 0,
+                        "lastWarningAt": None,
+                    },
                 },
             ],
-            "summary": {"total": 2, "pending": 1, "viewed": 0, "completed": 1},
+            "summary": {
+                "total": 2, "pending": 1, "viewed": 0, "completed": 1,
+                "voided": 0, "expired": 0, "waitingOn": 1,
+            },
         }
+
+    def voided_response(self):
+        """A voided document: the unsigned signer is stranded, the signed one is not."""
+        payload = self.mock_response()
+        payload["document"]["status"] = "voided"
+        payload["recipients"][1]["effectiveStatus"] = "voided"
+        payload["summary"] = {
+            "total": 2, "pending": 0, "viewed": 0, "completed": 1,
+            "voided": 1, "expired": 0, "waitingOn": 0,
+        }
+        return payload
+
+    @pytest.mark.asyncio
+    async def test_reports_email_history_per_recipient(self):
+        """Should report when each recipient was emailed and how many times"""
+        with patch.object(TurboSign, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=self.mock_response())
+            mock_get_client.return_value = mock_client
+
+            TurboSign.configure(api_key="test-key", org_id="test-org", sender_email="test@example.com")
+            result = await TurboSign.get_recipients("doc-123")
+
+            chased = result["recipients"][0]["delivery"]
+            assert chased["totalSent"] == 3
+            assert chased["firstSentOn"] == "2026-01-02T09:00:00.000Z"
+            assert chased["lastSentOn"] == "2026-01-09T09:00:00.000Z"
+            assert chased["reminderCount"] == 1
+            # A recipient emailed once has no reminders
+            assert result["recipients"][1]["delivery"]["totalSent"] == 1
+            assert result["recipients"][1]["delivery"]["lastRemindedAt"] is None
+            assert result["document"]["sentOn"] == "2026-01-02T08:59:00.000Z"
+
+    @pytest.mark.asyncio
+    async def test_surfaces_voided_effective_status_without_revoking_a_signature(self):
+        """Should strand unsigned recipients on a voided document but keep completed ones"""
+        with patch.object(TurboSign, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=self.voided_response())
+            mock_get_client.return_value = mock_client
+
+            TurboSign.configure(api_key="test-key", org_id="test-org", sender_email="test@example.com")
+            result = await TurboSign.get_recipients("doc-123")
+
+            # Someone who signed still signed — voiding the document does not undo it
+            assert result["recipients"][0]["effectiveStatus"] == "completed"
+            # The unsigned signer is stranded, though the raw DB status is still "pending"
+            assert result["recipients"][1]["status"] == "pending"
+            assert result["recipients"][1]["effectiveStatus"] == "voided"
+            assert result["summary"]["voided"] == 1
+            assert result["summary"]["waitingOn"] == 0
 
     @pytest.mark.asyncio
     async def test_get_every_recipient_with_status(self):
@@ -376,6 +451,7 @@ class TestGetRecipients:
 
             assert len(result["recipients"]) == 2
             assert result["recipients"][0]["status"] == "completed"
+            assert result["recipients"][0]["effectiveStatus"] == "completed"
             assert result["recipients"][0]["email"] == "john@example.com"
             assert result["recipients"][0]["signedOn"] == "2026-02-01T10:00:00.000Z"
             assert result["recipients"][0]["signingOrder"] == 1
@@ -398,7 +474,10 @@ class TestGetRecipients:
             assert result["document"]["sentBy"] == {"name": "Jane Sender", "email": "jane@acme.com"}
             # Document status distinguishes a voided/expired doc from one still waiting
             assert result["document"]["status"] == "under_review"
-            assert result["summary"] == {"total": 2, "pending": 1, "viewed": 0, "completed": 1}
+            assert result["summary"] == {
+                "total": 2, "pending": 1, "viewed": 0, "completed": 1,
+                "voided": 0, "expired": 0, "waitingOn": 1,
+            }
 
     @pytest.mark.asyncio
     async def test_raises_not_found_for_unknown_document(self):

--- a/packages/py-sdk/tests/test_turbosign.py
+++ b/packages/py-sdk/tests/test_turbosign.py
@@ -324,6 +324,95 @@ class TestGetStatus:
             mock_client.get.assert_called_once_with("/turbosign/documents/doc-123/status")
 
 
+class TestGetRecipients:
+    """Test get_recipients operation"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        TurboSign._client = None
+
+    def mock_response(self):
+        """The wire shape after the HTTP client unwraps {data: ...}"""
+        return {
+            "document": {
+                "id": "doc-123",
+                "name": "Mutual NDA",
+                "status": "under_review",
+                "createdOn": "2026-01-01T00:00:00.000Z",
+                "expiresAt": None,
+                "sentBy": {"name": "Jane Sender", "email": "jane@acme.com"},
+            },
+            "recipients": [
+                {
+                    "id": "rec-1",
+                    "name": "John Signer",
+                    "email": "john@example.com",
+                    "status": "completed",
+                    "signedOn": "2026-02-01T10:00:00.000Z",
+                    "signingOrder": 1,
+                },
+                {
+                    "id": "rec-2",
+                    "name": "Ada Signer",
+                    "email": "ada@example.com",
+                    "status": "pending",
+                    "signedOn": None,
+                    "signingOrder": 2,
+                },
+            ],
+            "summary": {"total": 2, "pending": 1, "viewed": 0, "completed": 1},
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_every_recipient_with_status(self):
+        """Should get every recipient with their signing status"""
+        with patch.object(TurboSign, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=self.mock_response())
+            mock_get_client.return_value = mock_client
+
+            TurboSign.configure(api_key="test-key", org_id="test-org", sender_email="test@example.com")
+            result = await TurboSign.get_recipients("doc-123")
+
+            assert len(result["recipients"]) == 2
+            assert result["recipients"][0]["status"] == "completed"
+            assert result["recipients"][0]["email"] == "john@example.com"
+            assert result["recipients"][0]["signedOn"] == "2026-02-01T10:00:00.000Z"
+            assert result["recipients"][0]["signingOrder"] == 1
+            # A pending signer has no signedOn timestamp
+            assert result["recipients"][1]["status"] == "pending"
+            assert result["recipients"][1]["signedOn"] is None
+            mock_client.get.assert_called_once_with("/turbosign/documents/doc-123/recipients")
+
+    @pytest.mark.asyncio
+    async def test_reports_sender_and_summary(self):
+        """Should expose who sent the document and the pending/completed roll-up"""
+        with patch.object(TurboSign, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=self.mock_response())
+            mock_get_client.return_value = mock_client
+
+            TurboSign.configure(api_key="test-key", org_id="test-org", sender_email="test@example.com")
+            result = await TurboSign.get_recipients("doc-123")
+
+            assert result["document"]["sentBy"] == {"name": "Jane Sender", "email": "jane@acme.com"}
+            # Document status distinguishes a voided/expired doc from one still waiting
+            assert result["document"]["status"] == "under_review"
+            assert result["summary"] == {"total": 2, "pending": 1, "viewed": 0, "completed": 1}
+
+    @pytest.mark.asyncio
+    async def test_raises_not_found_for_unknown_document(self):
+        """Should propagate NotFoundError for an unknown document"""
+        with patch.object(TurboSign, '_get_client') as mock_get_client:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(side_effect=NotFoundError("Document not found"))
+            mock_get_client.return_value = mock_client
+
+            TurboSign.configure(api_key="test-key", org_id="test-org", sender_email="test@example.com")
+            with pytest.raises(NotFoundError):
+                await TurboSign.get_recipients("missing-doc")
+
+
 class TestDownload:
     """Test download operation"""
 

--- a/packages/py-sdk/tests/test_turbosign.py
+++ b/packages/py-sdk/tests/test_turbosign.py
@@ -375,7 +375,8 @@ class TestGetRecipients:
                         "lastSentOn": "2026-01-02T09:00:00.000Z",
                         "totalSent": 1,
                         "reminderCount": 0,
-                        "lastRemindedAt": None,
+                        # Stamped by the initial send — NOT evidence of a reminder.
+                        "lastRemindedAt": "2026-01-02T09:00:00.000Z",
                         "warningCount": 0,
                         "lastWarningAt": None,
                     },
@@ -414,9 +415,12 @@ class TestGetRecipients:
             assert chased["firstSentOn"] == "2026-01-02T09:00:00.000Z"
             assert chased["lastSentOn"] == "2026-01-09T09:00:00.000Z"
             assert chased["reminderCount"] == 1
-            # A recipient emailed once has no reminders
-            assert result["recipients"][1]["delivery"]["totalSent"] == 1
-            assert result["recipients"][1]["delivery"]["lastRemindedAt"] is None
+            # Emailed once and never reminded: reminderCount stays 0, but lastRemindedAt
+            # is NOT None — the initial send stamps it as the reminder cadence clock.
+            once = result["recipients"][1]["delivery"]
+            assert once["totalSent"] == 1
+            assert once["reminderCount"] == 0
+            assert once["lastRemindedAt"] == once["firstSentOn"]
             assert result["document"]["sentOn"] == "2026-01-02T08:59:00.000Z"
 
     @pytest.mark.asyncio

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -232,16 +232,40 @@ The document source can also be raw bytes or a local file path (`file: File.binr
 
 #### `get_status(document_id)`
 
-Check the status of a document.
+Check the document-level status. For per-recipient detail, use `get_recipients`.
 
 ```ruby
 status = TurboDocxSdk::TurboSign.get_status("doc-uuid")
-puts "Status: #{status['status']}"  # "pending" | "completed" | "voided"
-
-status["recipients"].each do |r|
-  puts "#{r['name']}: #{r['status']}"
-end
+puts "Status: #{status['status']}"  # "under_review" | "completed" | "voided" | ...
 ```
+
+#### `get_recipients(document_id)`
+
+See who the document went to, who has signed, who you are still waiting on, and who sent it.
+
+```ruby
+result = TurboDocxSdk::TurboSign.get_recipients("doc-uuid")
+
+sender = result["document"]["sentBy"]
+puts "Sent by #{sender['name']} <#{sender['email']}>"
+
+summary = result["summary"]
+puts "#{summary['completed']} of #{summary['total']} signed, #{summary['pending']} not started"
+
+result["recipients"].each do |r|
+  # "pending" | "viewed" | "completed"
+  puts "#{r['name']} <#{r['email']}>: #{r['status']}"
+  puts "  signed #{r['signedOn']}" if r["signedOn"]
+end
+
+# Who are we chasing?
+waiting_on = result["recipients"].reject { |r| r["status"] == "completed" }
+```
+
+> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
+> there is no per-recipient declined or expired state. On a voided or expired document every
+> unsigned recipient still reads `pending`, so check `result["document"]["status"]` before
+> treating someone as "still to sign".
 
 #### `download(document_id)`
 

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -223,9 +223,13 @@ result = TurboDocxSdk::TurboSign.send_signature(
   ]
 )
 
+# The created recipients come back on the send result — each carries id, name and email.
+# Signing links are emailed to them; they are not returned here.
 result["recipients"].each do |r|
-  puts "#{r['name']}: #{r['signUrl']}"
+  puts "#{r['name']} <#{r['email']}> — #{r['id']}"
 end
+
+# For signing progress afterwards, use get_recipients.
 ```
 
 The document source can also be raw bytes or a local file path (`file: File.binread("contract.pdf")` or `file: "contract.pdf"` — the file type is detected from magic bytes), a TurboDocx deliverable (`deliverableId:`), or a TurboSign template (`templateId:`).

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -287,6 +287,15 @@ the document is terminal.
 request, resends, reminders, expiry warnings and terminal notices. CC notifications are
 excluded, since a CC address is not a signer.
 
+Two `delivery` fields are easy to misread:
+
+| Field | What it actually means |
+|---|---|
+| `reminderCount` | **Automatic (scheduled) reminders only** — the counter `maxReminders` caps. A manual "remind now" does **not** increment it (it must not consume the cap budget), though it does land in `totalSent`. So it can read `0` while reminder emails have genuinely been sent. |
+| `lastRemindedAt` | **When the reminder cadence clock was last reset** — not necessarily when a reminder was sent. The initial signature-request send, each scheduled reminder, each manual "remind now" and each expiry warning all stamp it. A freshly-sent document therefore normally reads a non-null `lastRemindedAt` alongside `reminderCount` of `0`. |
+
+`warningCount` and `lastWarningAt` are touched only by an expiry warning.
+
 #### `download(document_id)`
 
 Download the signed document as raw bytes.

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -250,22 +250,38 @@ sender = result["document"]["sentBy"]
 puts "Sent by #{sender['name']} <#{sender['email']}>"
 
 summary = result["summary"]
-puts "#{summary['completed']} of #{summary['total']} signed, #{summary['pending']} not started"
+puts "#{summary['completed']} of #{summary['total']} signed, waiting on #{summary['waitingOn']}"
 
 result["recipients"].each do |r|
-  # "pending" | "viewed" | "completed"
-  puts "#{r['name']} <#{r['email']}>: #{r['status']}"
+  # "pending" | "viewed" | "completed" | "voided" | "expired"
+  puts "#{r['name']} <#{r['email']}>: #{r['effectiveStatus']}"
   puts "  signed #{r['signedOn']}" if r["signedOn"]
+  puts "  emailed #{r['delivery']['totalSent']}x"
 end
 
 # Who are we chasing?
-waiting_on = result["recipients"].reject { |r| r["status"] == "completed" }
+chasing = result["recipients"].select { |r| %w[pending viewed].include?(r["effectiveStatus"]) }
 ```
 
-> **Overlay the document status.** Recipient status is only `pending` / `viewed` / `completed` —
-> there is no per-recipient declined or expired state. On a voided or expired document every
-> unsigned recipient still reads `pending`, so check `result["document"]["status"]` before
-> treating someone as "still to sign".
+**Two status fields, and they differ on purpose:**
+
+| Field | Values | Use it for |
+|---|---|---|
+| `status` | `pending`, `viewed`, `completed` | The raw database value |
+| `effectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |
+
+The database has no per-recipient declined/voided/expired state, so on a voided or expired
+document an unsigned signer still reads `pending` in `status`. `effectiveStatus` layers the
+document's outcome on top — that's the one to show a user. A completed signature is never
+revoked: someone who signed before the document was voided still reads `completed`.
+
+`summary` counts by `effectiveStatus`, and `waitingOn` (pending + viewed) drops to zero once
+the document is terminal.
+
+**`delivery`** is that recipient's email history — `firstSentOn`, `lastSentOn`, `totalSent`,
+`reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt`. It counts the signature
+request, resends, reminders, expiry warnings and terminal notices. CC notifications are
+excluded, since a CC address is not a signer.
 
 #### `download(document_id)`
 

--- a/packages/ruby-sdk/examples/turbosign_send_simple.rb
+++ b/packages/ruby-sdk/examples/turbosign_send_simple.rb
@@ -110,17 +110,18 @@ begin
   puts "Document ID: #{result['documentId']}"
   puts "Message: #{result['message']}"
 
-  # To get sign URLs and recipient details, use get_status
+  # Signing links are emailed to recipients — they are not returned by the API.
+  # get_recipients reports who has signed and who you are still waiting on.
   begin
-    status = TurboDocxSdk::TurboSign.get_status(result["documentId"])
-    if status["recipients"]
-      puts "\nSign URLs:"
-      status["recipients"].each do |recipient|
-        puts "  #{recipient['name']}: #{recipient['signUrl'] || 'N/A'}"
-      end
+    progress = TurboDocxSdk::TurboSign.get_recipients(result["documentId"])
+    summary = progress["summary"]
+    puts "\n#{summary['completed']} of #{summary['total']} signed, " \
+         "still waiting on #{summary['waitingOn']}"
+    progress["recipients"].each do |recipient|
+      puts "  #{recipient['name']} <#{recipient['email']}>: #{recipient['effectiveStatus']}"
     end
   rescue TurboDocxSdk::TurboDocxError
-    puts "\nNote: Could not fetch recipient sign URLs"
+    puts "\nNote: Could not fetch recipient status"
   end
 rescue TurboDocxSdk::TurboDocxError => e
   puts "Error: #{e.message}"

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
@@ -187,6 +187,19 @@ module TurboDocxSdk
       # Each recipient's "delivery" is their email history — CC notifications are
       # excluded, since a CC address is not a signer.
       #
+      # Two delivery fields are easy to misread:
+      #   * "reminderCount" counts AUTOMATIC (scheduled) reminders only — the counter
+      #     maxReminders caps. A manual "remind now" does not increment it (it must not
+      #     consume the cap budget), though it does land in "totalSent". So it can read 0
+      #     while reminder emails have genuinely been sent.
+      #   * "lastRemindedAt" is when the reminder CADENCE CLOCK was last reset, not
+      #     necessarily when a reminder was sent. The initial signature-request send, each
+      #     scheduled reminder, each manual "remind now" and each expiry warning all stamp
+      #     it — so a freshly-sent document normally reads a non-nil "lastRemindedAt"
+      #     alongside "reminderCount" of 0.
+      #
+      # "warningCount" / "lastWarningAt" are touched only by an expiry warning.
+      #
       # @param document_id [String]
       # @return [Hash] with "document" (id, name, status, createdOn, sentOn, expiresAt,
       #   sentBy), "recipients" (each with "status", "effectiveStatus", "signedOn",

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
@@ -178,15 +178,21 @@ module TurboDocxSdk
       # Answers "who has signed and who are we still waiting on" in one call, and
       # reports who sent the document.
       #
-      # There is no per-recipient declined/expired/voided state, so on a voided or
-      # expired document every unsigned recipient still reads "pending" — read
-      # result["document"]["status"] to tell "still waiting" apart from
-      # "this document is dead".
+      # "status" is the raw database value and is only ever "pending", "viewed" or
+      # "completed". "effectiveStatus" layers the document's terminal state on top and is
+      # what you should display: a signer on a voided or expired document reads
+      # "voided"/"expired" there while "status" still says "pending". A completed
+      # signature is never revoked.
+      #
+      # Each recipient's "delivery" is their email history — CC notifications are
+      # excluded, since a CC address is not a signer.
       #
       # @param document_id [String]
-      # @return [Hash] with "document" (including "sentBy"), "recipients"
-      #   (each with "status", "signedOn", "signingOrder") and "summary"
-      #   ("total", "pending", "viewed", "completed")
+      # @return [Hash] with "document" (id, name, status, createdOn, sentOn, expiresAt,
+      #   sentBy), "recipients" (each with "status", "effectiveStatus", "signedOn",
+      #   "signingOrder" and "delivery" = firstSentOn/lastSentOn/totalSent/
+      #   reminderCount/lastRemindedAt/warningCount/lastWarningAt) and "summary"
+      #   ("total", "pending", "viewed", "completed", "voided", "expired", "waitingOn")
       # @raise [NotFoundError] if the document does not exist
       # @raise [AuthenticationError] on invalid credentials
       # @raise [NetworkError] on connection failure

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_sign.rb
@@ -173,6 +173,28 @@ module TurboDocxSdk
         client.get("/turbosign/documents/#{document_id}/status")
       end
 
+      # Get every recipient on a document with their signing status.
+      #
+      # Answers "who has signed and who are we still waiting on" in one call, and
+      # reports who sent the document.
+      #
+      # There is no per-recipient declined/expired/voided state, so on a voided or
+      # expired document every unsigned recipient still reads "pending" — read
+      # result["document"]["status"] to tell "still waiting" apart from
+      # "this document is dead".
+      #
+      # @param document_id [String]
+      # @return [Hash] with "document" (including "sentBy"), "recipients"
+      #   (each with "status", "signedOn", "signingOrder") and "summary"
+      #   ("total", "pending", "viewed", "completed")
+      # @raise [NotFoundError] if the document does not exist
+      # @raise [AuthenticationError] on invalid credentials
+      # @raise [NetworkError] on connection failure
+      def get_recipients(document_id)
+        client = get_client
+        client.get("/turbosign/documents/#{document_id}/recipients")
+      end
+
       private
 
       def get_client

--- a/packages/ruby-sdk/spec/turbo_sign_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_sign_spec.rb
@@ -410,6 +410,7 @@ RSpec.describe TurboDocxSdk::TurboSign do
           "name" => "Mutual NDA",
           "status" => "under_review",
           "createdOn" => "2026-01-01T00:00:00.000Z",
+          "sentOn" => "2026-01-02T08:59:00.000Z",
           "expiresAt" => nil,
           "sentBy" => { "name" => "Jane Sender", "email" => "jane@acme.com" }
         },
@@ -419,20 +420,58 @@ RSpec.describe TurboDocxSdk::TurboSign do
             "name" => "John Signer",
             "email" => "john@example.com",
             "status" => "completed",
+            "effectiveStatus" => "completed",
             "signedOn" => "2026-02-01T10:00:00.000Z",
-            "signingOrder" => 1
+            "signingOrder" => 1,
+            "delivery" => {
+              "firstSentOn" => "2026-01-02T09:00:00.000Z",
+              "lastSentOn" => "2026-01-09T09:00:00.000Z",
+              "totalSent" => 3,
+              "reminderCount" => 1,
+              "lastRemindedAt" => "2026-01-09T09:00:00.000Z",
+              "warningCount" => 0,
+              "lastWarningAt" => nil
+            }
           },
           {
             "id" => "rec-2",
             "name" => "Ada Signer",
             "email" => "ada@example.com",
             "status" => "pending",
+            "effectiveStatus" => "pending",
             "signedOn" => nil,
-            "signingOrder" => 2
+            "signingOrder" => 2,
+            "delivery" => {
+              "firstSentOn" => "2026-01-02T09:00:00.000Z",
+              "lastSentOn" => "2026-01-02T09:00:00.000Z",
+              "totalSent" => 1,
+              "reminderCount" => 0,
+              "lastRemindedAt" => nil,
+              "warningCount" => 0,
+              "lastWarningAt" => nil
+            }
           }
         ],
-        "summary" => { "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1 }
+        "summary" => {
+          "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1,
+          "voided" => 0, "expired" => 0, "waitingOn" => 1
+        }
       }
+    end
+
+    # A voided document: the unsigned signer is stranded, the signed one keeps their signature.
+    let(:mock_voided_response) do
+      mock_recipients_response.merge(
+        "document" => mock_recipients_response["document"].merge("status" => "voided"),
+        "recipients" => [
+          mock_recipients_response["recipients"][0],
+          mock_recipients_response["recipients"][1].merge("effectiveStatus" => "voided")
+        ],
+        "summary" => {
+          "total" => 2, "pending" => 0, "viewed" => 0, "completed" => 1,
+          "voided" => 1, "expired" => 0, "waitingOn" => 0
+        }
+      )
     end
 
     before do
@@ -450,6 +489,7 @@ RSpec.describe TurboDocxSdk::TurboSign do
 
       expect(result["recipients"].length).to eq(2)
       expect(result["recipients"][0]["status"]).to eq("completed")
+      expect(result["recipients"][0]["effectiveStatus"]).to eq("completed")
       expect(result["recipients"][0]["email"]).to eq("john@example.com")
       expect(result["recipients"][0]["signedOn"]).to eq("2026-02-01T10:00:00.000Z")
       expect(result["recipients"][0]["signingOrder"]).to eq(1)
@@ -471,9 +511,42 @@ RSpec.describe TurboDocxSdk::TurboSign do
       )
       # Document status distinguishes a voided/expired doc from one still waiting
       expect(result["document"]["status"]).to eq("under_review")
+      expect(result["document"]["sentOn"]).to eq("2026-01-02T08:59:00.000Z")
       expect(result["summary"]).to eq(
-        { "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1 }
+        {
+          "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1,
+          "voided" => 0, "expired" => 0, "waitingOn" => 1
+        }
       )
+    end
+
+    it "reports each recipient's email history" do
+      allow(mock_client).to receive(:get).and_return(mock_recipients_response)
+
+      result = described_class.get_recipients("doc-123")
+
+      chased = result["recipients"][0]["delivery"]
+      expect(chased["totalSent"]).to eq(3)
+      expect(chased["firstSentOn"]).to eq("2026-01-02T09:00:00.000Z")
+      expect(chased["lastSentOn"]).to eq("2026-01-09T09:00:00.000Z")
+      expect(chased["reminderCount"]).to eq(1)
+      # A recipient emailed once has no reminders
+      expect(result["recipients"][1]["delivery"]["totalSent"]).to eq(1)
+      expect(result["recipients"][1]["delivery"]["lastRemindedAt"]).to be_nil
+    end
+
+    it "surfaces voided as an effective status without revoking a signature" do
+      allow(mock_client).to receive(:get).and_return(mock_voided_response)
+
+      result = described_class.get_recipients("doc-123")
+
+      # Someone who signed still signed — voiding the document does not undo it
+      expect(result["recipients"][0]["effectiveStatus"]).to eq("completed")
+      # The unsigned signer is stranded, though the raw DB status is still "pending"
+      expect(result["recipients"][1]["status"]).to eq("pending")
+      expect(result["recipients"][1]["effectiveStatus"]).to eq("voided")
+      expect(result["summary"]["voided"]).to eq(1)
+      expect(result["summary"]["waitingOn"]).to eq(0)
     end
 
     it "propagates a not found error for an unknown document" do

--- a/packages/ruby-sdk/spec/turbo_sign_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_sign_spec.rb
@@ -446,7 +446,8 @@ RSpec.describe TurboDocxSdk::TurboSign do
               "lastSentOn" => "2026-01-02T09:00:00.000Z",
               "totalSent" => 1,
               "reminderCount" => 0,
-              "lastRemindedAt" => nil,
+              # Stamped by the initial send — NOT evidence of a reminder.
+              "lastRemindedAt" => "2026-01-02T09:00:00.000Z",
               "warningCount" => 0,
               "lastWarningAt" => nil
             }
@@ -530,9 +531,12 @@ RSpec.describe TurboDocxSdk::TurboSign do
       expect(chased["firstSentOn"]).to eq("2026-01-02T09:00:00.000Z")
       expect(chased["lastSentOn"]).to eq("2026-01-09T09:00:00.000Z")
       expect(chased["reminderCount"]).to eq(1)
-      # A recipient emailed once has no reminders
-      expect(result["recipients"][1]["delivery"]["totalSent"]).to eq(1)
-      expect(result["recipients"][1]["delivery"]["lastRemindedAt"]).to be_nil
+      # Emailed once and never reminded: reminderCount stays 0, but lastRemindedAt is
+      # NOT nil — the initial send stamps it as the reminder cadence clock.
+      once = result["recipients"][1]["delivery"]
+      expect(once["totalSent"]).to eq(1)
+      expect(once["reminderCount"]).to eq(0)
+      expect(once["lastRemindedAt"]).to eq(once["firstSentOn"])
     end
 
     it "surfaces voided as an effective status without revoking a signature" do

--- a/packages/ruby-sdk/spec/turbo_sign_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_sign_spec.rb
@@ -398,6 +398,94 @@ RSpec.describe TurboDocxSdk::TurboSign do
   end
 
   # ============================================
+  # getRecipients
+  # ============================================
+
+  describe ".get_recipients" do
+    # The wire shape after the HTTP client unwraps {data: ...}
+    let(:mock_recipients_response) do
+      {
+        "document" => {
+          "id" => "doc-123",
+          "name" => "Mutual NDA",
+          "status" => "under_review",
+          "createdOn" => "2026-01-01T00:00:00.000Z",
+          "expiresAt" => nil,
+          "sentBy" => { "name" => "Jane Sender", "email" => "jane@acme.com" }
+        },
+        "recipients" => [
+          {
+            "id" => "rec-1",
+            "name" => "John Signer",
+            "email" => "john@example.com",
+            "status" => "completed",
+            "signedOn" => "2026-02-01T10:00:00.000Z",
+            "signingOrder" => 1
+          },
+          {
+            "id" => "rec-2",
+            "name" => "Ada Signer",
+            "email" => "ada@example.com",
+            "status" => "pending",
+            "signedOn" => nil,
+            "signingOrder" => 2
+          }
+        ],
+        "summary" => { "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1 }
+      }
+    end
+
+    before do
+      described_class.configure(
+        api_key: "test-key",
+        org_id: "org-1",
+        sender_email: "test@company.com"
+      )
+    end
+
+    it "gets every recipient with their signing status" do
+      allow(mock_client).to receive(:get).and_return(mock_recipients_response)
+
+      result = described_class.get_recipients("doc-123")
+
+      expect(result["recipients"].length).to eq(2)
+      expect(result["recipients"][0]["status"]).to eq("completed")
+      expect(result["recipients"][0]["email"]).to eq("john@example.com")
+      expect(result["recipients"][0]["signedOn"]).to eq("2026-02-01T10:00:00.000Z")
+      expect(result["recipients"][0]["signingOrder"]).to eq(1)
+      # A pending signer has no signedOn timestamp
+      expect(result["recipients"][1]["status"]).to eq("pending")
+      expect(result["recipients"][1]["signedOn"]).to be_nil
+      expect(mock_client).to have_received(:get).with(
+        "/turbosign/documents/doc-123/recipients"
+      )
+    end
+
+    it "exposes who sent the document and the pending/completed roll-up" do
+      allow(mock_client).to receive(:get).and_return(mock_recipients_response)
+
+      result = described_class.get_recipients("doc-123")
+
+      expect(result["document"]["sentBy"]).to eq(
+        { "name" => "Jane Sender", "email" => "jane@acme.com" }
+      )
+      # Document status distinguishes a voided/expired doc from one still waiting
+      expect(result["document"]["status"]).to eq("under_review")
+      expect(result["summary"]).to eq(
+        { "total" => 2, "pending" => 1, "viewed" => 0, "completed" => 1 }
+      )
+    end
+
+    it "propagates a not found error for an unknown document" do
+      allow(mock_client).to receive(:get).and_raise(TurboDocxSdk::NotFoundError, "Document not found")
+
+      expect {
+        described_class.get_recipients("missing-doc")
+      }.to raise_error(TurboDocxSdk::NotFoundError, "Document not found")
+    end
+  end
+
+  # ============================================
   # download
   # ============================================
 


### PR DESCRIPTION
## Description

Adds `getRecipients` to TurboSign across all six SDKs — the method that answers "who has signed, who are we still waiting on, and have we actually emailed them". Previously `getStatus()` returned only the document-level status, so callers had to combine the roster endpoint with the audit trail and derive per-recipient state themselves.

### Per-language surface

| SDK | Method | Returns |
|---|---|---|
| JS/TS | `getRecipients()` | `DocumentRecipientsResponse` |
| Python | `get_recipients()` | `Dict[str, Any]` |
| Go | `GetRecipients()` | `*DocumentRecipientsResponse` |
| PHP | `getRecipients()` | `DocumentRecipientsResponse` |
| Java | `getRecipients()` | `DocumentRecipientsResponse` |
| Ruby | `get_recipients` | `Hash` |

Python and Ruby return the raw dict/hash, matching how they already handle every other TurboSign read. That split is recorded in the parity rule as sanctioned, not a gap.

### Two status fields, on purpose

| Field | Values | Use it for |
|---|---|---|
| `status` | `pending`, `viewed`, `completed` | The raw database value |
| `effectiveStatus` | `pending`, `viewed`, `completed`, `voided`, `expired` | Display |

The schema has no per-recipient declined/voided/expired state, so on a voided or expired document an unsigned signer still reads `pending` in `status`. `effectiveStatus` layers the document's outcome on top. A completed signature is never revoked — someone who signed before the document was voided still reads `completed`. `summary` counts by `effectiveStatus` and adds `voided`, `expired` and `waitingOn` (pending + viewed, zero once terminal).

### Email history

Each recipient carries a `delivery` block: `firstSentOn`, `lastSentOn`, `totalSent`, `reminderCount`, `lastRemindedAt`, `warningCount`, `lastWarningAt`. It counts the signature request, resends, reminders, expiry warnings and terminal notices, and excludes CC notifications since a CC address is not a signer. `document.sentOn` reports when the document actually went out (null while it is still a draft).

### Documentation fixes included

Five of the six READMEs documented `getStatus()` as returning a `recipients` array whose entries had a `declined` status. It never did — the type is `{ status }` only, and no `declined` status exists anywhere. Those examples are corrected and now point at `getRecipients()`. A second stale example in the PHP quickstart read `recipients` off `getStatus()` too; it now reads them off the `sendSignature()` result, matching the other five SDKs.

## Testing

All six suites green:

| SDK | Result |
|---|---|
| js-sdk | 311 passed |
| py-sdk | 324 passed |
| go-sdk | ok (`go vet` clean) |
| php-sdk | 347 passed, phpstan clean |
| java-sdk | 310 passed |
| ruby-sdk | 308 examples, 0 failures |

Five scenarios per language, per `.claude/rules/testing.md` test parity: happy path, sender + summary, not-found error mapping, email history, and the voided-document effective-status overlay.

## Versioning

No version bump — this ships with the next release, at which point all six bump in lockstep per `.claude/rules/versioning.md`.

## Pre-Review Checklist

- [x] Tests pass
- [x] Cross-SDK parity table + notes updated
- [x] READMEs updated (method section + checklist)
- [x] No breaking changes — purely additive
