### PR TITLE
feat: partner org display preferences across all SDKs

### DIFF
--- a/.claude/rules/cross-sdk-parity.md
+++ b/.claude/rules/cross-sdk-parity.md
@@ -79,6 +79,7 @@ so a freshly-sent document normally reads a non-null `lastRemindedAt` alongside
 
 - Organization CRUD: create, list, getDetails, update, delete
 - Organization entitlements: updateEntitlements
+- Organization display preferences: getOrganizationPreferences, updateOrganizationPreferences
 - Organization users: list, add, update role, remove, resend invitation
 - Organization API keys: list, create, update, revoke
 - Partner API keys: list, create, update, revoke

--- a/examples/partner-preferences/README.md
+++ b/examples/partner-preferences/README.md
@@ -1,0 +1,65 @@
+# Example: partner-settable org preferences
+
+Small runnable scripts that show **what a partner sees** when managing a child
+organization's TurboSign display preferences through the SDK — and prove the
+change actually persists.
+
+Each script does the same three steps:
+
+1. **Read** the tenant's current preferences (`getOrganizationPreferences`)
+2. **Flip** the locked-fields background (`updateOrganizationPreferences`)
+3. **Read back** to confirm the value stuck
+
+The three preferences a partner can set per tenant:
+
+| Preference | Meaning |
+|------------|---------|
+| `hideSignatureOutline` | hide the outline/label on signed fields in the finished PDF |
+| `hideSignatureHash` | hide the verification hash on signed fields |
+| `lockedFieldsBackground` | show locked fields as a grey box (`true`) or plain text (`false`) |
+
+The API returns **only** these keys (never the org's other integration settings),
+each with its effective value (defaults applied for keys the org never set).
+
+## Setup
+
+You need a **partner API key** (`TDXP-…`), the partner's id, and the UUID of a
+child org that partner owns. Point the SDK at your backend with `TURBODOCX_BASE_URL`.
+
+```bash
+export TURBODOCX_BASE_URL=http://localhost:3001
+export TURBODOCX_PARTNER_API_KEY=TDXP-your-key
+export TURBODOCX_PARTNER_ID=your-partner-uuid
+export ORG_ID=a-child-org-uuid
+```
+
+## JavaScript
+
+```bash
+# build the SDK once
+(cd ../../packages/js-sdk && npm ci && npm run build)
+
+node js/read-and-set-preferences.mjs
+```
+
+## Python
+
+```bash
+(cd ../../packages/py-sdk && pip install -e .)
+
+python3 python/read_and_set_preferences.py
+```
+
+## Expected output
+
+```
+BEFORE: outline=true hash=true lockedGreyBackground=true
+UPDATED: outline=true hash=true lockedGreyBackground=false
+AFTER : outline=true hash=true lockedGreyBackground=false
+
+OK — the partner changed lockedFieldsBackground to false and it stuck.
+```
+
+If the partner isn't allowed to set a given key (its grant doesn't cover it), the
+API responds 403 and the SDK raises a typed authorization error — try it by
+requesting a key outside the partner's `allowedFields`.

--- a/examples/partner-preferences/js/read-and-set-preferences.mjs
+++ b/examples/partner-preferences/js/read-and-set-preferences.mjs
@@ -1,0 +1,61 @@
+// Example: what a partner sees when managing a tenant's TurboSign display
+// preferences through the SDK. Reads a child org's preferences, flips the
+// locked-fields background, and reads them back to prove the change stuck.
+//
+// Run:
+//   TURBODOCX_BASE_URL=http://localhost:3001 \
+//   TURBODOCX_PARTNER_API_KEY=TDXP-... \
+//   TURBODOCX_PARTNER_ID=<partner-uuid> \
+//   ORG_ID=<child-org-uuid> \
+//   node examples/partner-preferences/js/read-and-set-preferences.mjs
+//
+// Uses the locally-built SDK (packages/js-sdk/dist). Run `npm run build` in
+// packages/js-sdk first.
+
+import { TurboPartner } from "../../../packages/js-sdk/dist/index.js";
+
+const ORG_ID = process.env.ORG_ID;
+if (!ORG_ID) {
+  console.error("Set ORG_ID to a child org UUID this partner owns.");
+  process.exit(1);
+}
+
+// Config comes from env vars (TURBODOCX_PARTNER_API_KEY / _PARTNER_ID / _BASE_URL).
+TurboPartner.configure({
+  partnerApiKey: process.env.TURBODOCX_PARTNER_API_KEY,
+  partnerId: process.env.TURBODOCX_PARTNER_ID,
+  baseUrl: process.env.TURBODOCX_BASE_URL,
+});
+
+const show = (label, prefs) =>
+  console.log(
+    `${label}: outline=${!prefs.hideSignatureOutline} hash=${!prefs.hideSignatureHash} ` +
+      `lockedGreyBackground=${prefs.lockedFieldsBackground}`,
+  );
+
+async function main() {
+  // 1. What does the partner see right now for this tenant?
+  const before = (await TurboPartner.getOrganizationPreferences(ORG_ID)).data.preferences;
+  show("BEFORE", before);
+
+  // 2. Flip the locked-fields background to the opposite of its current value.
+  const next = !before.lockedFieldsBackground;
+  const updated = (
+    await TurboPartner.updateOrganizationPreferences(ORG_ID, { lockedFieldsBackground: next })
+  ).data.preferences;
+  show("UPDATED", updated);
+
+  // 3. Read it back fresh to prove it persisted.
+  const after = (await TurboPartner.getOrganizationPreferences(ORG_ID)).data.preferences;
+  show("AFTER ", after);
+
+  if (after.lockedFieldsBackground !== next) {
+    throw new Error("Round-trip mismatch: the value did not persist.");
+  }
+  console.log(`\nOK — the partner changed lockedFieldsBackground to ${next} and it stuck.`);
+}
+
+main().catch((err) => {
+  console.error("FAILED:", err.code || "", err.message);
+  process.exit(1);
+});

--- a/examples/partner-preferences/python/read_and_set_preferences.py
+++ b/examples/partner-preferences/python/read_and_set_preferences.py
@@ -1,0 +1,66 @@
+"""Example: what a partner sees when managing a tenant's TurboSign display
+preferences through the SDK. Reads a child org's preferences, flips the
+locked-fields background, and reads them back to prove the change stuck.
+
+Run (from packages/py-sdk installed, or with the repo on PYTHONPATH):
+
+    TURBODOCX_BASE_URL=http://localhost:3001 \\
+    TURBODOCX_PARTNER_API_KEY=TDXP-... \\
+    TURBODOCX_PARTNER_ID=<partner-uuid> \\
+    ORG_ID=<child-org-uuid> \\
+    python3 examples/partner-preferences/python/read_and_set_preferences.py
+"""
+
+import asyncio
+import os
+import sys
+
+from turbodocx_sdk import TurboPartner
+
+
+def show(label, prefs):
+    print(
+        f"{label}: outline={not prefs['hideSignatureOutline']} "
+        f"hash={not prefs['hideSignatureHash']} "
+        f"lockedGreyBackground={prefs['lockedFieldsBackground']}"
+    )
+
+
+async def main():
+    org_id = os.environ.get("ORG_ID")
+    if not org_id:
+        print("Set ORG_ID to a child org UUID this partner owns.", file=sys.stderr)
+        sys.exit(1)
+
+    # Config comes from env vars (TURBODOCX_PARTNER_API_KEY / _PARTNER_ID / _BASE_URL).
+    TurboPartner.configure(
+        partner_api_key=os.environ["TURBODOCX_PARTNER_API_KEY"],
+        partner_id=os.environ["TURBODOCX_PARTNER_ID"],
+        base_url=os.environ.get("TURBODOCX_BASE_URL"),
+    )
+
+    # 1. What does the partner see right now for this tenant?
+    before = (await TurboPartner.get_organization_preferences(org_id))["data"]["preferences"]
+    show("BEFORE", before)
+
+    # 2. Flip the locked-fields background to the opposite of its current value.
+    #    Note: the request key stays camelCase — it is an API field, not a Python name.
+    nxt = not before["lockedFieldsBackground"]
+    updated = (
+        await TurboPartner.update_organization_preferences(
+            org_id, {"lockedFieldsBackground": nxt}
+        )
+    )["data"]["preferences"]
+    show("UPDATED", updated)
+
+    # 3. Read it back fresh to prove it persisted.
+    after = (await TurboPartner.get_organization_preferences(org_id))["data"]["preferences"]
+    show("AFTER ", after)
+
+    if after["lockedFieldsBackground"] != nxt:
+        raise SystemExit("Round-trip mismatch: the value did not persist.")
+    print(f"\nOK — the partner changed lockedFieldsBackground to {nxt} and it stuck.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -434,9 +434,30 @@ entitlements, err := partner.UpdateOrganizationEntitlements(ctx, orgID, &turbodo
     },
 })
 
+// Read the org's TurboSign display preferences
+// (returns only the partner-settable keys, with defaults applied)
+prefs, err := partner.GetOrganizationPreferences(ctx, orgID)
+fmt.Println(prefs.Data.Preferences.LockedFieldsBackground) // true by default
+
+// Update them — every field is a *bool with omitempty, so a nil field is left
+// untouched and an explicit false is still sent. Every other organization
+// setting is preserved.
+updated, err := partner.UpdateOrganizationPreferences(ctx, orgID,
+    &turbodocx.UpdateOrgPreferencesRequest{
+        LockedFieldsBackground: turbodocx.BoolPtr(false),
+    })
+
 // Delete organization
 _, err := partner.DeleteOrganization(ctx, orgID)
 ```
+
+**Partner-settable display preferences**
+
+| Field | Default | Effect |
+|-------|---------|--------|
+| `HideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
+| `HideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
+| `LockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
 
 #### Organization User Management
 

--- a/packages/go-sdk/turbopartner.go
+++ b/packages/go-sdk/turbopartner.go
@@ -300,6 +300,14 @@ type UpdateEntitlementsRequest struct {
 	Tracking *Tracking `json:"tracking,omitempty"`
 }
 
+// UpdateOrgPreferencesRequest is the partial set of TurboSign display preferences to change.
+// Only the keys you set are sent (pointers with omitempty); a nil field is left untouched.
+type UpdateOrgPreferencesRequest struct {
+	HideSignatureOutline   *bool `json:"hideSignatureOutline,omitempty"`
+	HideSignatureHash      *bool `json:"hideSignatureHash,omitempty"`
+	LockedFieldsBackground *bool `json:"lockedFieldsBackground,omitempty"`
+}
+
 // AddOrgUserRequest is the request to add a user to an organization
 type AddOrgUserRequest struct {
 	Email string `json:"email"`
@@ -436,6 +444,23 @@ type EntitlementsResponse struct {
 	Data    struct {
 		Features *Features `json:"features,omitempty"`
 		Tracking *Tracking `json:"tracking,omitempty"`
+	} `json:"data"`
+}
+
+// PartnerOrgPreferences is the partner-settable slice of an organization's TurboSign
+// display preferences. Every key is present with its effective boolean value when read.
+type PartnerOrgPreferences struct {
+	HideSignatureOutline   bool `json:"hideSignatureOutline"`
+	HideSignatureHash      bool `json:"hideSignatureHash"`
+	LockedFieldsBackground bool `json:"lockedFieldsBackground"`
+}
+
+// PartnerOrgPreferencesResponse is the response for reading or updating an organization's
+// partner-settable preferences.
+type PartnerOrgPreferencesResponse struct {
+	Success bool `json:"success"`
+	Data    struct {
+		Preferences PartnerOrgPreferences `json:"preferences"`
 	} `json:"data"`
 }
 
@@ -623,6 +648,29 @@ func (c *PartnerClient) DeleteOrganization(ctx context.Context, organizationID s
 func (c *PartnerClient) UpdateOrganizationEntitlements(ctx context.Context, organizationID string, req *UpdateEntitlementsRequest) (*EntitlementsResponse, error) {
 	var response EntitlementsResponse
 	err := c.http.Patch(ctx, c.basePath()+"/organizations/"+organizationID+"/entitlements", req, &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// GetOrganizationPreferences reads the TurboSign display preferences for one of the
+// partner's organizations. Returns each partner-settable key with its effective value.
+func (c *PartnerClient) GetOrganizationPreferences(ctx context.Context, organizationID string) (*PartnerOrgPreferencesResponse, error) {
+	var response PartnerOrgPreferencesResponse
+	err := c.http.Get(ctx, c.basePath()+"/organizations/"+organizationID+"/preferences", &response)
+	if err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+// UpdateOrganizationPreferences sets TurboSign display preferences for one of the partner's
+// organizations. Only the keys set on preferences are sent, wrapped under a "preferences" key.
+func (c *PartnerClient) UpdateOrganizationPreferences(ctx context.Context, organizationID string, preferences *UpdateOrgPreferencesRequest) (*PartnerOrgPreferencesResponse, error) {
+	body := map[string]*UpdateOrgPreferencesRequest{"preferences": preferences}
+	var response PartnerOrgPreferencesResponse
+	err := c.http.Patch(ctx, c.basePath()+"/organizations/"+organizationID+"/preferences", body, &response)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-sdk/turbopartner_test.go
+++ b/packages/go-sdk/turbopartner_test.go
@@ -3,8 +3,10 @@ package turbodocx
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,6 +317,71 @@ func TestUpdateOrganizationEntitlements(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, result.Success)
 		assert.Equal(t, 100, *result.Data.Features.MaxUsers)
+	})
+}
+
+func TestGetOrganizationPreferences(t *testing.T) {
+	t.Run("gets preferences", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/organizations/org-123/preferences", r.URL.Path)
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"preferences": map[string]interface{}{
+						"hideSignatureOutline":   true,
+						"hideSignatureHash":      false,
+						"lockedFieldsBackground": true,
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.GetOrganizationPreferences(context.Background(), "org-123")
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.True(t, result.Data.Preferences.HideSignatureOutline)
+		assert.False(t, result.Data.Preferences.HideSignatureHash)
+		assert.True(t, result.Data.Preferences.LockedFieldsBackground)
+	})
+}
+
+func TestUpdateOrganizationPreferences(t *testing.T) {
+	t.Run("updates preferences", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "PATCH", r.Method)
+			assert.Equal(t, "/partner/test-partner-id/organizations/org-123/preferences", r.URL.Path)
+
+			rawBody, _ := io.ReadAll(r.Body)
+			assert.Equal(t, `{"preferences":{"lockedFieldsBackground":false}}`, strings.TrimSpace(string(rawBody)))
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": true,
+				"data": map[string]interface{}{
+					"preferences": map[string]interface{}{
+						"hideSignatureOutline":   true,
+						"hideSignatureHash":      false,
+						"lockedFieldsBackground": false,
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		client := newTestPartnerClient(t, server.URL)
+		result, err := client.UpdateOrganizationPreferences(context.Background(), "org-123", &UpdateOrgPreferencesRequest{
+			LockedFieldsBackground: BoolPtr(false),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Success)
+		assert.False(t, result.Data.Preferences.LockedFieldsBackground)
 	})
 }
 

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -398,6 +398,8 @@ The `TurboPartner` module provides partner portal operations for managing organi
 ```java
 import com.turbodocx.TurboPartnerClient;
 import com.turbodocx.PartnerScope;
+import com.turbodocx.models.PartnerOrgPreferences;
+import com.turbodocx.models.PartnerOrgPreferencesResponse;
 import com.google.gson.JsonObject;
 
 TurboPartnerClient client = new TurboPartnerClient.Builder()
@@ -438,9 +440,28 @@ client.turboPartner().updateOrganizationInfo(orgId, "Acme Corporation");
 Map<String, Object> newFeatures = Map.of("maxUsers", 100, "hasTDAI", true);
 client.turboPartner().updateOrganizationEntitlements(orgId, newFeatures, null);
 
+// Read the org's TurboSign display preferences
+// (returns only the partner-settable keys, with defaults applied)
+PartnerOrgPreferencesResponse read = client.turboPartner().getOrganizationPreferences(orgId);
+System.out.println(read.getData().getPreferences().getLockedFieldsBackground()); // true by default
+
+// Update them — any field left null is omitted, so you change only what you name
+// and every other organization setting is preserved. An explicit false IS sent.
+client.turboPartner().updateOrganizationPreferences(
+    orgId,
+    new PartnerOrgPreferences().setLockedFieldsBackground(false));
+
 // Delete an organization
 client.turboPartner().deleteOrganization(orgId);
 ```
+
+**Partner-settable display preferences**
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
+| `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
+| `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
 
 ### Organization User Management
 
@@ -607,6 +628,7 @@ for (int i = 0; i < results.size(); i++) {
 | Category | Method |
 |:---------|:-------|
 | **Organizations** | `createOrganization()`, `listOrganizations()`, `getOrganizationDetails()`, `updateOrganizationInfo()`, `deleteOrganization()`, `updateOrganizationEntitlements()` |
+| **Org display preferences** | `getOrganizationPreferences()`, `updateOrganizationPreferences()` |
 | **Org Users** | `addUserToOrganization()`, `listOrganizationUsers()`, `updateOrganizationUserRole()`, `removeUserFromOrganization()`, `resendOrganizationInvitationToUser()` |
 | **Org API Keys** | `createOrganizationApiKey()`, `listOrganizationApiKeys()`, `updateOrganizationApiKey()`, `revokeOrganizationApiKey()` |
 | **Partner API Keys** | `createPartnerApiKey()`, `listPartnerApiKeys()`, `updatePartnerApiKey()`, `revokePartnerApiKey()` |

--- a/packages/java-sdk/src/main/java/com/turbodocx/TurboPartner.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/TurboPartner.java
@@ -1,6 +1,9 @@
 package com.turbodocx;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.turbodocx.models.PartnerOrgPreferences;
+import com.turbodocx.models.PartnerOrgPreferencesResponse;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -29,6 +32,7 @@ public final class TurboPartner {
 
     private final PartnerHttpClient httpClient;
     private final String partnerId;
+    private final Gson gson = new Gson();
 
     TurboPartner(PartnerHttpClient httpClient, String partnerId) {
         this.httpClient = httpClient;
@@ -147,6 +151,53 @@ public final class TurboPartner {
             body.put("tracking", tracking);
         }
         return httpClient.patch(basePath() + "/organizations/" + organizationId + "/entitlements", body);
+    }
+
+    /**
+     * Read the TurboSign display preferences for one of the partner's organizations.
+     *
+     * <p>Returns only the partner-settable preference keys, each with its effective
+     * value (defaults applied for keys the org never set). Lets a partner see a
+     * tenant's current settings before changing them.</p>
+     *
+     * @param organizationId Organization UUID
+     * @return the organization's partner-settable preferences ({@code success}, {@code data.preferences})
+     * @throws IOException if the request fails
+     */
+    public PartnerOrgPreferencesResponse getOrganizationPreferences(String organizationId) throws IOException {
+        JsonObject response = httpClient.get(basePath() + "/organizations/" + organizationId + "/preferences");
+        return gson.fromJson(response, PartnerOrgPreferencesResponse.class);
+    }
+
+    /**
+     * Set TurboSign display preferences for one of the partner's organizations.
+     *
+     * <p>Pass only the keys you want to change; leave the rest null and they are
+     * omitted from the request body. Any key the partner isn't permitted to set is
+     * rejected by the API. The full effective preferences are returned.</p>
+     *
+     * @param organizationId Organization UUID
+     * @param preferences    The preference keys to change (null-valued fields are omitted)
+     * @return the organization's updated partner-settable preferences
+     * @throws IOException if the request fails
+     */
+    public PartnerOrgPreferencesResponse updateOrganizationPreferences(String organizationId, PartnerOrgPreferences preferences) throws IOException {
+        Map<String, Object> preferencesBody = new LinkedHashMap<>();
+        if (preferences != null) {
+            if (preferences.getHideSignatureOutline() != null) {
+                preferencesBody.put("hideSignatureOutline", preferences.getHideSignatureOutline());
+            }
+            if (preferences.getHideSignatureHash() != null) {
+                preferencesBody.put("hideSignatureHash", preferences.getHideSignatureHash());
+            }
+            if (preferences.getLockedFieldsBackground() != null) {
+                preferencesBody.put("lockedFieldsBackground", preferences.getLockedFieldsBackground());
+            }
+        }
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("preferences", preferencesBody);
+        JsonObject response = httpClient.patch(basePath() + "/organizations/" + organizationId + "/preferences", body);
+        return gson.fromJson(response, PartnerOrgPreferencesResponse.class);
     }
 
     // =========================================================================

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferences.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferences.java
@@ -1,0 +1,55 @@
+package com.turbodocx.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * The partner-settable slice of an organization's TurboSign display preferences.
+ *
+ * <p>When read, every key is present with its effective boolean value (defaults
+ * applied for keys the org never set). When used as an update body, leave a field
+ * null to omit it -- only non-null keys are sent, so a partner changes just the
+ * keys it wants. Widening this class later (as the backend allowlist grows) is
+ * additive and non-breaking.</p>
+ *
+ * <p>JSON keys are camelCase verbatim -- they are not re-cased.</p>
+ */
+public class PartnerOrgPreferences {
+    @SerializedName("hideSignatureOutline")
+    private Boolean hideSignatureOutline;
+
+    @SerializedName("hideSignatureHash")
+    private Boolean hideSignatureHash;
+
+    @SerializedName("lockedFieldsBackground")
+    private Boolean lockedFieldsBackground;
+
+    public PartnerOrgPreferences() {
+    }
+
+    public Boolean getHideSignatureOutline() {
+        return hideSignatureOutline;
+    }
+
+    public PartnerOrgPreferences setHideSignatureOutline(Boolean hideSignatureOutline) {
+        this.hideSignatureOutline = hideSignatureOutline;
+        return this;
+    }
+
+    public Boolean getHideSignatureHash() {
+        return hideSignatureHash;
+    }
+
+    public PartnerOrgPreferences setHideSignatureHash(Boolean hideSignatureHash) {
+        this.hideSignatureHash = hideSignatureHash;
+        return this;
+    }
+
+    public Boolean getLockedFieldsBackground() {
+        return lockedFieldsBackground;
+    }
+
+    public PartnerOrgPreferences setLockedFieldsBackground(Boolean lockedFieldsBackground) {
+        this.lockedFieldsBackground = lockedFieldsBackground;
+        return this;
+    }
+}

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferencesResponse.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferencesResponse.java
@@ -1,0 +1,37 @@
+package com.turbodocx.models;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Response wrapper for reading or updating an organization's partner-settable
+ * TurboSign display preferences.
+ *
+ * <p>Matches the API envelope {@code { success, data: { preferences } }}.</p>
+ */
+public class PartnerOrgPreferencesResponse {
+    @SerializedName("success")
+    private boolean success;
+
+    @SerializedName("data")
+    private Data data;
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    /**
+     * The {@code data} envelope holding the preferences object.
+     */
+    public static class Data {
+        @SerializedName("preferences")
+        private PartnerOrgPreferences preferences;
+
+        public PartnerOrgPreferences getPreferences() {
+            return preferences;
+        }
+    }
+}

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerTest.java
@@ -2,6 +2,8 @@ package com.turbodocx;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.turbodocx.models.PartnerOrgPreferences;
+import com.turbodocx.models.PartnerOrgPreferencesResponse;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -331,6 +333,49 @@ class TurboPartnerTest {
         String body = request.getBody().readUtf8();
         assertTrue(body.contains("\"features\""));
         assertTrue(body.contains("\"tracking\""));
+    }
+
+    @Test
+    @DisplayName("should get organization preferences and return effective values")
+    void getOrganizationPreferences() throws Exception {
+        enqueueSuccess(Map.of("success", true, "data",
+                Map.of("preferences", Map.of(
+                        "hideSignatureOutline", false,
+                        "hideSignatureHash", false,
+                        "lockedFieldsBackground", true))));
+
+        PartnerOrgPreferencesResponse result = client.turboPartner().getOrganizationPreferences("org-1");
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getData().getPreferences().getLockedFieldsBackground());
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("GET", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/organizations/org-1/preferences", request.getPath());
+    }
+
+    @Test
+    @DisplayName("should PATCH only the given preferences wrapped in a preferences envelope")
+    void updateOrganizationPreferences() throws Exception {
+        enqueueSuccess(Map.of("success", true, "data",
+                Map.of("preferences", Map.of(
+                        "hideSignatureOutline", false,
+                        "hideSignatureHash", false,
+                        "lockedFieldsBackground", false))));
+
+        PartnerOrgPreferencesResponse result = client.turboPartner().updateOrganizationPreferences(
+                "org-1",
+                new PartnerOrgPreferences().setLockedFieldsBackground(false));
+
+        assertFalse(result.getData().getPreferences().getLockedFieldsBackground());
+
+        RecordedRequest request = server.takeRequest();
+        assertEquals("PATCH", request.getMethod());
+        assertEquals("/partner/" + PARTNER_ID + "/organizations/org-1/preferences", request.getPath());
+        // The request body wraps the partial preferences under a `preferences` key, and
+        // only the one key set by the caller is sent (the null fields are omitted).
+        String body = request.getBody().readUtf8();
+        assertEquals("{\"preferences\":{\"lockedFieldsBackground\":false}}", body);
     }
 
     // ============================================

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -424,7 +424,26 @@ await TurboPartner.deleteOrganization('org-uuid');
 await TurboPartner.updateOrganizationEntitlements('org-uuid', {
   features: { maxUsers: 100, hasTDAI: true },
 });
+
+// Read an organization's TurboSign display preferences
+// (returns only the partner-settable keys, with defaults applied)
+const { data } = await TurboPartner.getOrganizationPreferences('org-uuid');
+console.log(data.preferences.lockedFieldsBackground); // true by default
+
+// Update them — pass only the keys you want to change; every other
+// organization setting is preserved
+await TurboPartner.updateOrganizationPreferences('org-uuid', {
+  lockedFieldsBackground: false, // render locked fields as plain text
+});
 ```
+
+**Partner-settable display preferences**
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
+| `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
+| `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
 
 #### Organization User Management
 

--- a/packages/js-sdk/src/modules/partner.ts
+++ b/packages/js-sdk/src/modules/partner.ts
@@ -27,6 +27,8 @@ import {
   OrganizationListResponse,
   OrganizationDetailResponse,
   EntitlementsResponse,
+  PartnerOrgPreferences,
+  PartnerOrgPreferencesResponse,
   OrgUserResponse,
   OrgUserListResponse,
   OrgApiKeyResponse,
@@ -230,6 +232,60 @@ export class TurboPartner {
     const client = this.getClient();
     const partnerId = this.getPartnerId();
     return client.patch<EntitlementsResponse>(`/partner/${partnerId}/organizations/${organizationId}/entitlements`, request);
+  }
+
+  /**
+   * Read the TurboSign display preferences for one of the partner's organizations.
+   *
+   * Returns only the partner-settable preference keys, each with its effective
+   * value (defaults applied for keys the org never set). Lets a partner see a
+   * tenant's current settings before changing them.
+   *
+   * @param organizationId - Organization ID
+   * @returns The organization's partner-settable preferences
+   *
+   * @example
+   * ```typescript
+   * const { data } = await TurboPartner.getOrganizationPreferences('org-uuid');
+   * console.log(data.preferences.lockedFieldsBackground);
+   * ```
+   */
+  static async getOrganizationPreferences(organizationId: string): Promise<PartnerOrgPreferencesResponse> {
+    const client = this.getClient();
+    const partnerId = this.getPartnerId();
+    return client.get<PartnerOrgPreferencesResponse>(
+      `/partner/${partnerId}/organizations/${organizationId}/preferences`
+    );
+  }
+
+  /**
+   * Set TurboSign display preferences for one of the partner's organizations.
+   *
+   * Pass only the keys you want to change; each must be a boolean. Any key the
+   * partner isn't permitted to set is rejected by the API. The full effective
+   * preferences are returned.
+   *
+   * @param organizationId - Organization ID
+   * @param preferences - The preference keys to change
+   * @returns The organization's updated partner-settable preferences
+   *
+   * @example
+   * ```typescript
+   * await TurboPartner.updateOrganizationPreferences('org-uuid', {
+   *   lockedFieldsBackground: false,
+   * });
+   * ```
+   */
+  static async updateOrganizationPreferences(
+    organizationId: string,
+    preferences: Partial<PartnerOrgPreferences>
+  ): Promise<PartnerOrgPreferencesResponse> {
+    const client = this.getClient();
+    const partnerId = this.getPartnerId();
+    return client.patch<PartnerOrgPreferencesResponse>(
+      `/partner/${partnerId}/organizations/${organizationId}/preferences`,
+      { preferences }
+    );
   }
 
   // ============================================

--- a/packages/js-sdk/src/types/partner.ts
+++ b/packages/js-sdk/src/types/partner.ts
@@ -311,6 +311,24 @@ export interface EntitlementsResponse {
   };
 }
 
+/**
+ * The partner-settable slice of an organization's display preferences. Every key
+ * is present with its effective boolean value when read. Widening this interface
+ * later (as the backend allowlist grows) is additive and non-breaking.
+ */
+export interface PartnerOrgPreferences {
+  hideSignatureOutline: boolean;
+  hideSignatureHash: boolean;
+  lockedFieldsBackground: boolean;
+}
+
+export interface PartnerOrgPreferencesResponse {
+  success: boolean;
+  data: {
+    preferences: PartnerOrgPreferences;
+  };
+}
+
 export interface OrgUserResponse {
   success: boolean;
   data: OrganizationUser;

--- a/packages/js-sdk/tests/turbopartner.test.ts
+++ b/packages/js-sdk/tests/turbopartner.test.ts
@@ -249,6 +249,49 @@ describe("TurboPartner Module", () => {
         );
       });
     });
+
+    describe("getOrganizationPreferences", () => {
+      it("should GET the org preferences and return the effective values", async () => {
+        const mockResponse = {
+          success: true,
+          data: {
+            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: true },
+          },
+        };
+        MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
+        setup();
+
+        const result = await TurboPartner.getOrganizationPreferences("org-1");
+
+        expect(result.data.preferences.lockedFieldsBackground).toBe(true);
+        expect(MockedHttpClient.prototype.get).toHaveBeenCalledWith(
+          `/partner/${PARTNER_ID}/organizations/org-1/preferences`
+        );
+      });
+    });
+
+    describe("updateOrganizationPreferences", () => {
+      it("should PATCH only the given preferences wrapped in a preferences envelope", async () => {
+        const mockResponse = {
+          success: true,
+          data: {
+            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: false },
+          },
+        };
+        MockedHttpClient.prototype.patch = jest.fn().mockResolvedValue(mockResponse);
+        setup();
+
+        const result = await TurboPartner.updateOrganizationPreferences("org-1", { lockedFieldsBackground: false });
+
+        expect(result.data.preferences.lockedFieldsBackground).toBe(false);
+        // The request body wraps the partial preferences under a `preferences` key,
+        // matching the backend PATCH contract. Only the given key is sent.
+        expect(MockedHttpClient.prototype.patch).toHaveBeenCalledWith(
+          `/partner/${PARTNER_ID}/organizations/org-1/preferences`,
+          { preferences: { lockedFieldsBackground: false } }
+        );
+      });
+    });
   });
 
   // ============================================

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -900,6 +900,36 @@ $result = TurboPartner::updateOrganizationEntitlements(
 );
 ```
 
+#### `getOrganizationPreferences()`
+
+Read an organization's TurboSign display preferences. Returns only the partner-settable keys, each with its effective value (defaults applied for keys the org never set) — never the organization's other settings.
+
+```php
+$prefs = TurboPartner::getOrganizationPreferences('org-uuid-here')->preferences;
+
+var_dump($prefs->hideSignatureOutline);   // false by default
+var_dump($prefs->hideSignatureHash);      // false by default
+var_dump($prefs->lockedFieldsBackground); // true by default
+```
+
+#### `updateOrganizationPreferences()`
+
+Set an organization's TurboSign display preferences. Pass only the keys you want to change as a plain camelCase array — the SDK wraps them under `preferences`, and every other organization setting is preserved.
+
+```php
+$result = TurboPartner::updateOrganizationPreferences('org-uuid-here', [
+    'lockedFieldsBackground' => false,  // render locked fields as plain text
+]);
+
+var_dump($result->preferences->lockedFieldsBackground); // false
+```
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
+| `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
+| `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+
 #### `deleteOrganization()`
 
 Delete an organization (use with caution).

--- a/packages/php-sdk/src/TurboPartner.php
+++ b/packages/php-sdk/src/TurboPartner.php
@@ -29,6 +29,7 @@ use TurboDocx\Types\Responses\Partner\OrgApiKeyResponse;
 use TurboDocx\Types\Responses\Partner\OrganizationDetailResponse;
 use TurboDocx\Types\Responses\Partner\OrganizationListResponse;
 use TurboDocx\Types\Responses\Partner\OrganizationResponse;
+use TurboDocx\Types\Responses\Partner\PartnerOrgPreferencesResponse;
 use TurboDocx\Types\Responses\Partner\OrgUserListResponse;
 use TurboDocx\Types\Responses\Partner\OrgUserResponse;
 use TurboDocx\Types\Responses\Partner\PartnerApiKeyListResponse;
@@ -204,6 +205,49 @@ final class TurboPartner
             $request->toArray()
         );
         return EntitlementsResponse::fromArray($response);
+    }
+
+    /**
+     * Read the TurboSign display preferences for one of the partner's organizations.
+     *
+     * Returns only the partner-settable preference keys, each with its effective
+     * value (defaults applied for keys the org never set).
+     *
+     * @param string $organizationId Organization UUID
+     * @return PartnerOrgPreferencesResponse
+     */
+    public static function getOrganizationPreferences(
+        string $organizationId
+    ): PartnerOrgPreferencesResponse {
+        $client = self::getClient();
+        $partnerId = self::getPartnerId();
+        $response = $client->get(
+            "/partner/{$partnerId}/organizations/{$organizationId}/preferences"
+        );
+        return PartnerOrgPreferencesResponse::fromArray($response);
+    }
+
+    /**
+     * Set TurboSign display preferences for one of the partner's organizations.
+     *
+     * Pass only the keys you want to change; each must be a boolean. Keys and the
+     * `preferences` wrapper are sent to the API verbatim (camelCase).
+     *
+     * @param string $organizationId Organization UUID
+     * @param array<string, bool> $preferences The preference keys to change
+     * @return PartnerOrgPreferencesResponse
+     */
+    public static function updateOrganizationPreferences(
+        string $organizationId,
+        array $preferences
+    ): PartnerOrgPreferencesResponse {
+        $client = self::getClient();
+        $partnerId = self::getPartnerId();
+        $response = $client->patch(
+            "/partner/{$partnerId}/organizations/{$organizationId}/preferences",
+            ['preferences' => $preferences]
+        );
+        return PartnerOrgPreferencesResponse::fromArray($response);
     }
 
     // ==================== Organization User Management ====================

--- a/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
+++ b/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Partner;
+
+/**
+ * The partner-settable slice of an organization's TurboSign display preferences.
+ * Every key is present with its effective boolean value when read.
+ */
+final class PartnerOrgPreferences implements \JsonSerializable
+{
+    public function __construct(
+        public readonly bool $hideSignatureOutline = false,
+        public readonly bool $hideSignatureHash = false,
+        public readonly bool $lockedFieldsBackground = false,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            hideSignatureOutline: (bool) ($data['hideSignatureOutline'] ?? false),
+            hideSignatureHash: (bool) ($data['hideSignatureHash'] ?? false),
+            lockedFieldsBackground: (bool) ($data['lockedFieldsBackground'] ?? false),
+        );
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function toArray(): array
+    {
+        return [
+            'hideSignatureOutline' => $this->hideSignatureOutline,
+            'hideSignatureHash' => $this->hideSignatureHash,
+            'lockedFieldsBackground' => $this->lockedFieldsBackground,
+        ];
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
+++ b/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
@@ -10,10 +10,14 @@ namespace TurboDocx\Types\Partner;
  */
 final class PartnerOrgPreferences implements \JsonSerializable
 {
+    // Defaults mirror the backend's PARTNER_PREFERENCE_DEFAULTS: the two "hide" flags
+    // are off, the locked-fields grey box is on. The API always sends all three keys,
+    // so these only surface on a hand-built instance or a truncated response -- but a
+    // `false` here would misreport the platform default for lockedFieldsBackground.
     public function __construct(
         public readonly bool $hideSignatureOutline = false,
         public readonly bool $hideSignatureHash = false,
-        public readonly bool $lockedFieldsBackground = false,
+        public readonly bool $lockedFieldsBackground = true,
     ) {}
 
     /**
@@ -25,7 +29,7 @@ final class PartnerOrgPreferences implements \JsonSerializable
         return new self(
             hideSignatureOutline: (bool) ($data['hideSignatureOutline'] ?? false),
             hideSignatureHash: (bool) ($data['hideSignatureHash'] ?? false),
-            lockedFieldsBackground: (bool) ($data['lockedFieldsBackground'] ?? false),
+            lockedFieldsBackground: (bool) ($data['lockedFieldsBackground'] ?? true),
         );
     }
 

--- a/packages/php-sdk/src/Types/Responses/Partner/PartnerOrgPreferencesResponse.php
+++ b/packages/php-sdk/src/Types/Responses/Partner/PartnerOrgPreferencesResponse.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Types\Responses\Partner;
+
+use TurboDocx\Types\Partner\PartnerOrgPreferences;
+
+/**
+ * Response from reading or updating an organization's partner-settable preferences
+ */
+final class PartnerOrgPreferencesResponse implements \JsonSerializable
+{
+    public function __construct(
+        public readonly bool $success,
+        public readonly PartnerOrgPreferences $preferences,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        $responseData = $data['data'] ?? $data;
+        $preferences = $responseData['preferences'] ?? [];
+
+        return new self(
+            success: (bool) ($data['success'] ?? true),
+            preferences: PartnerOrgPreferences::fromArray(is_array($preferences) ? $preferences : []),
+        );
+    }
+
+    /**
+     * Convert to array for serialization
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'success' => $this->success,
+            'data' => [
+                'preferences' => $this->preferences->toArray(),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/packages/php-sdk/tests/Unit/TurboPartnerPreferencesTest.php
+++ b/packages/php-sdk/tests/Unit/TurboPartnerPreferencesTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TurboDocx\Tests\Unit;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use ReflectionClass;
+use TurboDocx\Config\PartnerClientConfig;
+use TurboDocx\HttpClient;
+use TurboDocx\TurboPartner;
+
+/**
+ * Tests for TurboPartner org-preferences methods.
+ *
+ * Mirrors the js-sdk turbopartner preference tests:
+ *   - getOrganizationPreferences GETs the right path and returns the effective values
+ *   - updateOrganizationPreferences PATCHes only the given keys wrapped in a
+ *     `preferences` envelope to the right path
+ *
+ * Uses a Guzzle MockHandler (matching TurboWebhooksTest) plus a history middleware
+ * to capture the outgoing request path and body.
+ */
+final class TurboPartnerPreferencesTest extends TestCase
+{
+    private const PARTNER_ID = '11111111-1111-4111-8111-111111111111';
+
+    /** @var array<int, array<string, mixed>> */
+    private array $requestHistory = [];
+
+    protected function setUp(): void
+    {
+        $this->resetPartnerClient();
+        $this->requestHistory = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetPartnerClient();
+    }
+
+    private function resetPartnerClient(): void
+    {
+        $ref = new ReflectionClass(TurboPartner::class);
+        foreach (['client', 'config'] as $name) {
+            $prop = $ref->getProperty($name);
+            $prop->setAccessible(true);
+            $prop->setValue(null, null);
+        }
+    }
+
+    /**
+     * Install a mocked HTTP client on TurboPartner that returns $body for the next
+     * request and records the outgoing request into $this->requestHistory.
+     */
+    private function installMockClient(int $status, string $body): void
+    {
+        $config = new PartnerClientConfig(
+            partnerApiKey: 'TDXP-test',
+            partnerId: self::PARTNER_ID,
+            baseUrl: 'http://localhost/',
+        );
+        $http = new HttpClient($config);
+
+        $mock = new MockHandler([new Response($status, [], $body)]);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($this->requestHistory));
+        $guzzle = new Client(['handler' => $stack, 'base_uri' => 'http://localhost/']);
+
+        $httpRef = new ReflectionClass($http);
+        $guzzleProp = $httpRef->getProperty('client');
+        $guzzleProp->setAccessible(true);
+        $guzzleProp->setValue($http, $guzzle);
+
+        $partnerRef = new ReflectionClass(TurboPartner::class);
+        $clientProp = $partnerRef->getProperty('client');
+        $clientProp->setAccessible(true);
+        $clientProp->setValue(null, $http);
+        $configProp = $partnerRef->getProperty('config');
+        $configProp->setAccessible(true);
+        $configProp->setValue(null, $config);
+    }
+
+    private function lastRequest(): RequestInterface
+    {
+        $this->assertNotEmpty($this->requestHistory, 'No HTTP request was captured');
+        return $this->requestHistory[count($this->requestHistory) - 1]['request'];
+    }
+
+    public function testGetOrganizationPreferencesGetsPathAndReturnsEffectiveValues(): void
+    {
+        $this->installMockClient(200, json_encode([
+            'success' => true,
+            'data' => [
+                'preferences' => [
+                    'hideSignatureOutline' => false,
+                    'hideSignatureHash' => false,
+                    'lockedFieldsBackground' => true,
+                ],
+            ],
+        ]) ?: '');
+
+        $result = TurboPartner::getOrganizationPreferences('org-1');
+
+        $this->assertTrue($result->preferences->lockedFieldsBackground);
+        $this->assertFalse($result->preferences->hideSignatureOutline);
+
+        $request = $this->lastRequest();
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame(
+            '/partner/' . self::PARTNER_ID . '/organizations/org-1/preferences',
+            $request->getUri()->getPath(),
+        );
+    }
+
+    public function testUpdateOrganizationPreferencesPatchesOnlyGivenKeysWrappedInEnvelope(): void
+    {
+        $this->installMockClient(200, json_encode([
+            'success' => true,
+            'data' => [
+                'preferences' => [
+                    'hideSignatureOutline' => false,
+                    'hideSignatureHash' => false,
+                    'lockedFieldsBackground' => false,
+                ],
+            ],
+        ]) ?: '');
+
+        $result = TurboPartner::updateOrganizationPreferences('org-1', [
+            'lockedFieldsBackground' => false,
+        ]);
+
+        $this->assertFalse($result->preferences->lockedFieldsBackground);
+
+        $request = $this->lastRequest();
+        $this->assertSame('PATCH', $request->getMethod());
+        $this->assertSame(
+            '/partner/' . self::PARTNER_ID . '/organizations/org-1/preferences',
+            $request->getUri()->getPath(),
+        );
+
+        // The body wraps only the given key under a `preferences` envelope,
+        // matching the backend PATCH contract. Keys stay camelCase verbatim.
+        $sentBody = json_decode((string) $request->getBody(), true);
+        $this->assertSame(
+            ['preferences' => ['lockedFieldsBackground' => false]],
+            $sentBody,
+        );
+    }
+}

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -439,9 +439,28 @@ await TurboPartner.update_organization_entitlements(
     org_id, features={"maxUsers": 50}
 )
 
+# Read the org's TurboSign display preferences
+# (returns only the partner-settable keys, with defaults applied)
+prefs = (await TurboPartner.get_organization_preferences(org_id))["data"]["preferences"]
+print(prefs["lockedFieldsBackground"])  # True by default
+
+# Update them — pass only the keys you want to change; every other organization
+# setting is preserved. Keys stay camelCase: they are the API contract.
+await TurboPartner.update_organization_preferences(
+    org_id, {"lockedFieldsBackground": False}
+)
+
 # Delete organization
 await TurboPartner.delete_organization(org_id)
 ```
+
+**Partner-settable display preferences**
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `hideSignatureOutline` | `False` | Hide the outline/label drawn around signed fields |
+| `hideSignatureHash` | `False` | Hide the verification hash printed on signed fields |
+| `lockedFieldsBackground` | `True` | Grey box behind locked fields (`False` = plain text) |
 
 #### Organization User & API Key Management
 
@@ -494,6 +513,7 @@ logs = await TurboPartner.get_partner_audit_logs(limit=10)
 | Category | Method |
 |:---------|:-------|
 | **Organizations** | `create_organization()`, `list_organizations()`, `get_organization_details()`, `update_organization_info()`, `delete_organization()`, `update_organization_entitlements()` |
+| **Org display preferences** | `get_organization_preferences()`, `update_organization_preferences()` |
 | **Org Users** | `add_user_to_organization()`, `list_organization_users()`, `update_organization_user_role()`, `remove_user_from_organization()`, `resend_organization_invitation_to_user()` |
 | **Org API Keys** | `create_organization_api_key()`, `list_organization_api_keys()`, `update_organization_api_key()`, `revoke_organization_api_key()` |
 | **Partner API Keys** | `create_partner_api_key()`, `list_partner_api_keys()`, `update_partner_api_key()`, `revoke_partner_api_key()` |

--- a/packages/py-sdk/src/turbodocx_sdk/modules/partner.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/partner.py
@@ -247,6 +247,55 @@ class TurboPartner:
             data=body
         )
 
+    @classmethod
+    async def get_organization_preferences(cls, organization_id: str) -> Dict[str, Any]:
+        """
+        Read an organization's TurboSign display preferences
+
+        Returns only the partner-settable preference keys, each with its effective
+        value (defaults applied for keys the org never set). Lets a partner see a
+        tenant's current settings before changing them.
+
+        Args:
+            organization_id: Organization UUID
+
+        Returns:
+            Dict with success and data (preferences: hideSignatureOutline,
+            hideSignatureHash, lockedFieldsBackground)
+        """
+        client = cls._get_client()
+        return await client.get(
+            f"{cls._base_path()}/organizations/{organization_id}/preferences"
+        )
+
+    @classmethod
+    async def update_organization_preferences(
+        cls,
+        organization_id: str,
+        preferences: Dict[str, bool]
+    ) -> Dict[str, Any]:
+        """
+        Set an organization's TurboSign display preferences
+
+        Pass only the keys you want to change; each must be a boolean. Keys stay
+        camelCase verbatim -- they are sent to the API unchanged. Any key the
+        partner isn't permitted to set is rejected by the API. The full effective
+        preferences are returned.
+
+        Args:
+            organization_id: Organization UUID
+            preferences: The preference keys to change (camelCase), e.g.
+                hideSignatureOutline, hideSignatureHash, lockedFieldsBackground
+
+        Returns:
+            Dict with success and data (updated preferences)
+        """
+        client = cls._get_client()
+        return await client.patch(
+            f"{cls._base_path()}/organizations/{organization_id}/preferences",
+            data={"preferences": preferences}
+        )
+
     # =========================================================================
     # Organization User Management
     # =========================================================================

--- a/packages/py-sdk/tests/test_turbopartner.py
+++ b/packages/py-sdk/tests/test_turbopartner.py
@@ -339,6 +339,74 @@ class TestUpdateOrganizationEntitlements:
             )
 
 
+class TestGetOrganizationPreferences:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+
+    @pytest.mark.asyncio
+    async def test_get_organization_preferences(self):
+        mock_response = {
+            "success": True,
+            "data": {
+                "preferences": {
+                    "hideSignatureOutline": False,
+                    "hideSignatureHash": False,
+                    "lockedFieldsBackground": True
+                }
+            }
+        }
+
+        with patch.object(TurboPartner, '_get_client') as mock_get:
+            mock_client = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+            TurboPartner._partner_id = PARTNER_ID
+
+            result = await TurboPartner.get_organization_preferences("org-123")
+
+            assert result["data"]["preferences"]["lockedFieldsBackground"] is True
+            mock_client.get.assert_called_once_with(
+                f"/partner/{PARTNER_ID}/organizations/org-123/preferences"
+            )
+
+
+class TestUpdateOrganizationPreferences:
+    def setup_method(self):
+        TurboPartner._client = None
+        TurboPartner._partner_id = None
+
+    @pytest.mark.asyncio
+    async def test_update_organization_preferences(self):
+        mock_response = {
+            "success": True,
+            "data": {
+                "preferences": {
+                    "hideSignatureOutline": False,
+                    "hideSignatureHash": False,
+                    "lockedFieldsBackground": False
+                }
+            }
+        }
+
+        with patch.object(TurboPartner, '_get_client') as mock_get:
+            mock_client = MagicMock()
+            mock_client.patch = AsyncMock(return_value=mock_response)
+            mock_get.return_value = mock_client
+            TurboPartner._partner_id = PARTNER_ID
+
+            result = await TurboPartner.update_organization_preferences(
+                "org-123", {"lockedFieldsBackground": False}
+            )
+
+            assert result["data"]["preferences"]["lockedFieldsBackground"] is False
+            # Only the given key, wrapped in a camelCase-verbatim "preferences" body
+            mock_client.patch.assert_called_once_with(
+                f"/partner/{PARTNER_ID}/organizations/org-123/preferences",
+                data={"preferences": {"lockedFieldsBackground": False}}
+            )
+
+
 # =========================================================================
 # Organization User Management
 # =========================================================================

--- a/packages/ruby-sdk/Gemfile.lock
+++ b/packages/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    turbodocx-sdk (0.6.1)
+    turbodocx-sdk (0.7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -506,7 +506,27 @@ TurboDocxSdk::TurboPartner.delete_organization("org-uuid")
 TurboDocxSdk::TurboPartner.update_organization_entitlements("org-uuid",
   features: { maxUsers: 100, hasTDAI: true }
 )
+
+# Read the org's TurboSign display preferences
+# (returns only the partner-settable keys, with defaults applied)
+prefs = TurboDocxSdk::TurboPartner.get_organization_preferences("org-uuid")["data"]["preferences"]
+prefs["lockedFieldsBackground"]   # => true by default
+
+# Update them — pass only the keys you want to change; every other organization
+# setting is preserved. Hash keys stay camelCase: they are the API contract, not
+# Ruby names, and a snake_case key is dropped by the backend allowlist.
+TurboDocxSdk::TurboPartner.update_organization_preferences("org-uuid",
+  "lockedFieldsBackground" => false
+)
 ```
+
+**Partner-settable display preferences**
+
+| Key | Default | Effect |
+|-----|---------|--------|
+| `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
+| `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
+| `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
 
 #### Organization User Management
 
@@ -640,6 +660,7 @@ end
 | Category | Methods |
 |:---------|:--------|
 | **Organizations** | `create_organization`, `list_organizations`, `get_organization_details`, `update_organization_info`, `delete_organization`, `update_organization_entitlements` |
+| **Org display preferences** | `get_organization_preferences`, `update_organization_preferences` |
 | **Org Users** | `add_user_to_organization`, `list_organization_users`, `update_organization_user_role`, `remove_user_from_organization`, `resend_organization_invitation_to_user` |
 | **Org API Keys** | `create_organization_api_key`, `list_organization_api_keys`, `update_organization_api_key`, `revoke_organization_api_key` |
 | **Partner API Keys** | `create_partner_api_key`, `list_partner_api_keys`, `update_partner_api_key`, `revoke_partner_api_key` |

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_partner.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_partner.rb
@@ -108,6 +108,44 @@ module TurboDocxSdk
         client.patch("/partner/#{partner_id}/organizations/#{organization_id}/entitlements", request)
       end
 
+      # Read the TurboSign display preferences for one of the partner's organizations.
+      #
+      # Returns only the partner-settable preference keys, each with its effective
+      # value (defaults applied for keys the org never set).
+      #
+      # @param organization_id [String]
+      # @return [Hash] the organization's partner-settable preferences under +data.preferences+
+      #   (+hideSignatureOutline+, +hideSignatureHash+, +lockedFieldsBackground+ booleans)
+      # @raise [NotFoundError] if the organization does not exist
+      # @raise [AuthenticationError] on invalid credentials
+      # @raise [NetworkError] on connection failure
+      def get_organization_preferences(organization_id)
+        client = get_client
+        client.get("/partner/#{partner_id}/organizations/#{organization_id}/preferences")
+      end
+
+      # Set TurboSign display preferences for one of the partner's organizations.
+      #
+      # Pass only the keys you want to change; each must be a boolean. The keys stay
+      # camelCase verbatim (+hideSignatureOutline+, +hideSignatureHash+,
+      # +lockedFieldsBackground+) -- they are the API contract, not Ruby names.
+      #
+      # @param organization_id [String]
+      # @param preferences [Hash] the preference keys to change (only these are sent)
+      # @return [Hash] the organization's updated partner-settable preferences under +data.preferences+
+      # @raise [NotFoundError] if the organization does not exist
+      # @raise [ValidationError] on invalid request data
+      # @raise [AuthenticationError] on invalid credentials
+      # @raise [NetworkError] on connection failure
+      def update_organization_preferences(organization_id, preferences)
+        client = get_client
+        # Wrap under :preferences without mutating the caller's hash.
+        client.patch(
+          "/partner/#{partner_id}/organizations/#{organization_id}/preferences",
+          { "preferences" => preferences.dup }
+        )
+      end
+
       # ============================================
       # ORGANIZATION USER MANAGEMENT
       # ============================================

--- a/packages/ruby-sdk/spec/turbo_partner_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_partner_spec.rb
@@ -221,6 +221,65 @@ RSpec.describe TurboDocxSdk::TurboPartner do
         )
       end
     end
+
+    describe ".get_organization_preferences" do
+      it "reads the org's TurboSign display preferences" do
+        mock_response = {
+          "success" => true,
+          "data" => {
+            "preferences" => {
+              "hideSignatureOutline" => false,
+              "hideSignatureHash" => false,
+              "lockedFieldsBackground" => true
+            }
+          }
+        }
+        allow(mock_client).to receive(:get).and_return(mock_response)
+
+        result = described_class.get_organization_preferences("org-1")
+
+        expect(result["data"]["preferences"]["lockedFieldsBackground"]).to eq(true)
+        expect(result["data"]["preferences"]["hideSignatureOutline"]).to eq(false)
+        expect(mock_client).to have_received(:get).with(
+          "/partner/#{partner_id}/organizations/org-1/preferences"
+        )
+      end
+    end
+
+    describe ".update_organization_preferences" do
+      it "sends only the given keys wrapped under preferences (camelCase verbatim)" do
+        mock_response = {
+          "success" => true,
+          "data" => {
+            "preferences" => {
+              "hideSignatureOutline" => false,
+              "hideSignatureHash" => false,
+              "lockedFieldsBackground" => false
+            }
+          }
+        }
+        allow(mock_client).to receive(:patch).and_return(mock_response)
+
+        result = described_class.update_organization_preferences("org-1",
+          "lockedFieldsBackground" => false
+        )
+
+        expect(result["data"]["preferences"]["lockedFieldsBackground"]).to eq(false)
+        expect(mock_client).to have_received(:patch).with(
+          "/partner/#{partner_id}/organizations/org-1/preferences",
+          { "preferences" => { "lockedFieldsBackground" => false } }
+        )
+      end
+
+      it "does not mutate the caller's preferences hash" do
+        allow(mock_client).to receive(:patch).and_return("success" => true, "data" => { "preferences" => {} })
+
+        caller_preferences = { "hideSignatureHash" => true }
+        described_class.update_organization_preferences("org-1", caller_preferences)
+
+        expect(caller_preferences).to eq({ "hideSignatureHash" => true })
+      end
+    end
   end
 
   # ============================================


### PR DESCRIPTION
## Description

Adds a `TurboPartner` method pair so a partner can read and set a child organization's TurboSign display preferences programmatically, per tenant:

```
getOrganizationPreferences(orgId)            // GET  .../organizations/:id/preferences
updateOrganizationPreferences(orgId, prefs)  // PATCH same, body { preferences: { ... } }
```

The three settable preferences: `hideSignatureOutline`, `hideSignatureHash`, `lockedFieldsBackground`. The API returns only these keys (never the org's other settings), each with its effective value.

## Cross-language parity

Implemented in **all six** SDKs with idiomatic method names:

| Language | Methods |
|----------|---------|
| JS / PHP / Java | `getOrganizationPreferences` / `updateOrganizationPreferences` |
| Python / Ruby | `get_organization_preferences` / `update_organization_preferences` |
| Go | `GetOrganizationPreferences` / `UpdateOrganizationPreferences` |

Consistency details that were explicitly reviewed and verified:
- The PATCH sends **only the given keys**, wrapped under `preferences`, with the API field names kept **verbatim camelCase** (not snake_cased in Python/Ruby).
- An explicit `false` is transmitted, not dropped — Go uses `*bool` + `omitempty`, Java gates on `!= null`.
- Ruby/Python/PHP do **not** mutate the caller's argument.
- The two-key `{ success, data: { preferences } }` envelope is returned intact (not smart-unwrapped).

Listed in `.claude/rules/cross-sdk-parity.md` under Required TurboPartner Operations.

## Examples

`examples/partner-preferences/` — runnable JS and Python scripts that read a tenant's preferences, flip the locked-fields background, and read back to confirm. Both were run end-to-end against a live backend.

## Tests

Per-language tests added (assert the exact path, the wrapped request body, and the response shape): js 52 partner tests, plus Python / Go / PHP (343) / Java (307) suites green. Ruby specs added (run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
