### PR TITLE
feat(partner): add allowDownloadBeforeSigning to org display preferences

### DIFF
--- a/examples/partner-preferences/README.md
+++ b/examples/partner-preferences/README.md
@@ -17,7 +17,7 @@ The preferences a partner can set per tenant:
 | `hideSignatureOutline` | hide the outline/label on signed fields in the finished PDF |
 | `hideSignatureHash` | hide the verification hash on signed fields |
 | `lockedFieldsBackground` | show locked fields as a grey box (`true`) or plain text (`false`) |
-| `allowDownloadBeforeSigning` | let a signer download the unsigned PDF from the signing page before they sign (`true`), for example to review it with their legal team; defaults to off (`false`) |
+| `allowDownloadBeforeSigning` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 The API returns **only** these keys (never the org's other integration settings),
 each with its effective value (defaults applied for keys the org never set).

--- a/examples/partner-preferences/README.md
+++ b/examples/partner-preferences/README.md
@@ -10,13 +10,14 @@ Each script does the same three steps:
 2. **Flip** the locked-fields background (`updateOrganizationPreferences`)
 3. **Read back** to confirm the value stuck
 
-The three preferences a partner can set per tenant:
+The preferences a partner can set per tenant:
 
 | Preference | Meaning |
 |------------|---------|
 | `hideSignatureOutline` | hide the outline/label on signed fields in the finished PDF |
 | `hideSignatureHash` | hide the verification hash on signed fields |
 | `lockedFieldsBackground` | show locked fields as a grey box (`true`) or plain text (`false`) |
+| `allowDownloadBeforeSigning` | let a signer download the unsigned PDF from the signing page before they sign (`true`), for example to review it with their legal team; defaults to off (`false`) |
 
 The API returns **only** these keys (never the org's other integration settings),
 each with its effective value (defaults applied for keys the org never set).
@@ -53,9 +54,9 @@ python3 python/read_and_set_preferences.py
 ## Expected output
 
 ```
-BEFORE: outline=true hash=true lockedGreyBackground=true
-UPDATED: outline=true hash=true lockedGreyBackground=false
-AFTER : outline=true hash=true lockedGreyBackground=false
+BEFORE: outline=true hash=true lockedGreyBackground=true download=false
+UPDATED: outline=true hash=true lockedGreyBackground=false download=false
+AFTER : outline=true hash=true lockedGreyBackground=false download=false
 
 OK — the partner changed lockedFieldsBackground to false and it stuck.
 ```

--- a/examples/partner-preferences/js/read-and-set-preferences.mjs
+++ b/examples/partner-preferences/js/read-and-set-preferences.mjs
@@ -30,7 +30,8 @@ TurboPartner.configure({
 const show = (label, prefs) =>
   console.log(
     `${label}: outline=${!prefs.hideSignatureOutline} hash=${!prefs.hideSignatureHash} ` +
-      `lockedGreyBackground=${prefs.lockedFieldsBackground}`,
+      `lockedGreyBackground=${prefs.lockedFieldsBackground} ` +
+      `download=${prefs.allowDownloadBeforeSigning}`,
   );
 
 async function main() {

--- a/examples/partner-preferences/python/read_and_set_preferences.py
+++ b/examples/partner-preferences/python/read_and_set_preferences.py
@@ -22,7 +22,8 @@ def show(label, prefs):
     print(
         f"{label}: outline={not prefs['hideSignatureOutline']} "
         f"hash={not prefs['hideSignatureHash']} "
-        f"lockedGreyBackground={prefs['lockedFieldsBackground']}"
+        f"lockedGreyBackground={prefs['lockedFieldsBackground']} "
+        f"download={prefs['allowDownloadBeforeSigning']}"
     )
 
 

--- a/packages/go-sdk/README.md
+++ b/packages/go-sdk/README.md
@@ -458,6 +458,7 @@ _, err := partner.DeleteOrganization(ctx, orgID)
 | `HideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `HideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `LockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+| `AllowDownloadBeforeSigning` | `false` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 #### Organization User Management
 

--- a/packages/go-sdk/turbopartner.go
+++ b/packages/go-sdk/turbopartner.go
@@ -303,9 +303,10 @@ type UpdateEntitlementsRequest struct {
 // UpdateOrgPreferencesRequest is the partial set of TurboSign display preferences to change.
 // Only the keys you set are sent (pointers with omitempty); a nil field is left untouched.
 type UpdateOrgPreferencesRequest struct {
-	HideSignatureOutline   *bool `json:"hideSignatureOutline,omitempty"`
-	HideSignatureHash      *bool `json:"hideSignatureHash,omitempty"`
-	LockedFieldsBackground *bool `json:"lockedFieldsBackground,omitempty"`
+	HideSignatureOutline       *bool `json:"hideSignatureOutline,omitempty"`
+	HideSignatureHash          *bool `json:"hideSignatureHash,omitempty"`
+	LockedFieldsBackground     *bool `json:"lockedFieldsBackground,omitempty"`
+	AllowDownloadBeforeSigning *bool `json:"allowDownloadBeforeSigning,omitempty"`
 }
 
 // AddOrgUserRequest is the request to add a user to an organization
@@ -450,9 +451,10 @@ type EntitlementsResponse struct {
 // PartnerOrgPreferences is the partner-settable slice of an organization's TurboSign
 // display preferences. Every key is present with its effective boolean value when read.
 type PartnerOrgPreferences struct {
-	HideSignatureOutline   bool `json:"hideSignatureOutline"`
-	HideSignatureHash      bool `json:"hideSignatureHash"`
-	LockedFieldsBackground bool `json:"lockedFieldsBackground"`
+	HideSignatureOutline       bool `json:"hideSignatureOutline"`
+	HideSignatureHash          bool `json:"hideSignatureHash"`
+	LockedFieldsBackground     bool `json:"lockedFieldsBackground"`
+	AllowDownloadBeforeSigning bool `json:"allowDownloadBeforeSigning"`
 }
 
 // PartnerOrgPreferencesResponse is the response for reading or updating an organization's

--- a/packages/go-sdk/turbopartner_test.go
+++ b/packages/go-sdk/turbopartner_test.go
@@ -331,9 +331,10 @@ func TestGetOrganizationPreferences(t *testing.T) {
 				"success": true,
 				"data": map[string]interface{}{
 					"preferences": map[string]interface{}{
-						"hideSignatureOutline":   true,
-						"hideSignatureHash":      false,
-						"lockedFieldsBackground": true,
+						"hideSignatureOutline":       true,
+						"hideSignatureHash":          false,
+						"lockedFieldsBackground":     true,
+						"allowDownloadBeforeSigning": false,
 					},
 				},
 			})
@@ -348,6 +349,7 @@ func TestGetOrganizationPreferences(t *testing.T) {
 		assert.True(t, result.Data.Preferences.HideSignatureOutline)
 		assert.False(t, result.Data.Preferences.HideSignatureHash)
 		assert.True(t, result.Data.Preferences.LockedFieldsBackground)
+		assert.False(t, result.Data.Preferences.AllowDownloadBeforeSigning)
 	})
 }
 
@@ -365,9 +367,10 @@ func TestUpdateOrganizationPreferences(t *testing.T) {
 				"success": true,
 				"data": map[string]interface{}{
 					"preferences": map[string]interface{}{
-						"hideSignatureOutline":   true,
-						"hideSignatureHash":      false,
-						"lockedFieldsBackground": false,
+						"hideSignatureOutline":       true,
+						"hideSignatureHash":          false,
+						"lockedFieldsBackground":     false,
+						"allowDownloadBeforeSigning": false,
 					},
 				},
 			})

--- a/packages/java-sdk/README.md
+++ b/packages/java-sdk/README.md
@@ -462,6 +462,7 @@ client.turboPartner().deleteOrganization(orgId);
 | `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+| `allowDownloadBeforeSigning` | `false` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 ### Organization User Management
 

--- a/packages/java-sdk/src/main/java/com/turbodocx/TurboPartner.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/TurboPartner.java
@@ -193,6 +193,9 @@ public final class TurboPartner {
             if (preferences.getLockedFieldsBackground() != null) {
                 preferencesBody.put("lockedFieldsBackground", preferences.getLockedFieldsBackground());
             }
+            if (preferences.getAllowDownloadBeforeSigning() != null) {
+                preferencesBody.put("allowDownloadBeforeSigning", preferences.getAllowDownloadBeforeSigning());
+            }
         }
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("preferences", preferencesBody);

--- a/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferences.java
+++ b/packages/java-sdk/src/main/java/com/turbodocx/models/PartnerOrgPreferences.java
@@ -23,6 +23,9 @@ public class PartnerOrgPreferences {
     @SerializedName("lockedFieldsBackground")
     private Boolean lockedFieldsBackground;
 
+    @SerializedName("allowDownloadBeforeSigning")
+    private Boolean allowDownloadBeforeSigning;
+
     public PartnerOrgPreferences() {
     }
 
@@ -50,6 +53,15 @@ public class PartnerOrgPreferences {
 
     public PartnerOrgPreferences setLockedFieldsBackground(Boolean lockedFieldsBackground) {
         this.lockedFieldsBackground = lockedFieldsBackground;
+        return this;
+    }
+
+    public Boolean getAllowDownloadBeforeSigning() {
+        return allowDownloadBeforeSigning;
+    }
+
+    public PartnerOrgPreferences setAllowDownloadBeforeSigning(Boolean allowDownloadBeforeSigning) {
+        this.allowDownloadBeforeSigning = allowDownloadBeforeSigning;
         return this;
     }
 }

--- a/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerTest.java
+++ b/packages/java-sdk/src/test/java/com/turbodocx/TurboPartnerTest.java
@@ -342,12 +342,14 @@ class TurboPartnerTest {
                 Map.of("preferences", Map.of(
                         "hideSignatureOutline", false,
                         "hideSignatureHash", false,
-                        "lockedFieldsBackground", true))));
+                        "lockedFieldsBackground", true,
+                        "allowDownloadBeforeSigning", false))));
 
         PartnerOrgPreferencesResponse result = client.turboPartner().getOrganizationPreferences("org-1");
 
         assertTrue(result.isSuccess());
         assertTrue(result.getData().getPreferences().getLockedFieldsBackground());
+        assertFalse(result.getData().getPreferences().getAllowDownloadBeforeSigning());
 
         RecordedRequest request = server.takeRequest();
         assertEquals("GET", request.getMethod());
@@ -361,7 +363,8 @@ class TurboPartnerTest {
                 Map.of("preferences", Map.of(
                         "hideSignatureOutline", false,
                         "hideSignatureHash", false,
-                        "lockedFieldsBackground", false))));
+                        "lockedFieldsBackground", false,
+                        "allowDownloadBeforeSigning", false))));
 
         PartnerOrgPreferencesResponse result = client.turboPartner().updateOrganizationPreferences(
                 "org-1",

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -445,7 +445,7 @@ await TurboPartner.updateOrganizationPreferences('org-uuid', {
 | `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
-| `allowDownloadBeforeSigning` | `false` | Let a signer download the unsigned PDF from the signing page before they sign (e.g. to review it with their legal team) |
+| `allowDownloadBeforeSigning` | `false` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 #### Organization User Management
 

--- a/packages/js-sdk/README.md
+++ b/packages/js-sdk/README.md
@@ -434,6 +434,7 @@ console.log(data.preferences.lockedFieldsBackground); // true by default
 // organization setting is preserved
 await TurboPartner.updateOrganizationPreferences('org-uuid', {
   lockedFieldsBackground: false, // render locked fields as plain text
+  allowDownloadBeforeSigning: true, // let signers download the unsigned PDF
 });
 ```
 
@@ -444,6 +445,7 @@ await TurboPartner.updateOrganizationPreferences('org-uuid', {
 | `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+| `allowDownloadBeforeSigning` | `false` | Let a signer download the unsigned PDF from the signing page before they sign (e.g. to review it with their legal team) |
 
 #### Organization User Management
 

--- a/packages/js-sdk/src/modules/partner.ts
+++ b/packages/js-sdk/src/modules/partner.ts
@@ -273,6 +273,7 @@ export class TurboPartner {
    * ```typescript
    * await TurboPartner.updateOrganizationPreferences('org-uuid', {
    *   lockedFieldsBackground: false,
+   *   allowDownloadBeforeSigning: true,
    * });
    * ```
    */

--- a/packages/js-sdk/src/types/partner.ts
+++ b/packages/js-sdk/src/types/partner.ts
@@ -320,6 +320,12 @@ export interface PartnerOrgPreferences {
   hideSignatureOutline: boolean;
   hideSignatureHash: boolean;
   lockedFieldsBackground: boolean;
+  /**
+   * When enabled, a signer can download the unsigned PDF from the signing page
+   * before they sign it (for example, to review it with their legal team).
+   * Defaults to off.
+   */
+  allowDownloadBeforeSigning: boolean;
 }
 
 export interface PartnerOrgPreferencesResponse {

--- a/packages/js-sdk/tests/turbopartner.test.ts
+++ b/packages/js-sdk/tests/turbopartner.test.ts
@@ -255,7 +255,7 @@ describe("TurboPartner Module", () => {
         const mockResponse = {
           success: true,
           data: {
-            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: true },
+            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: true, allowDownloadBeforeSigning: false },
           },
         };
         MockedHttpClient.prototype.get = jest.fn().mockResolvedValue(mockResponse);
@@ -275,7 +275,7 @@ describe("TurboPartner Module", () => {
         const mockResponse = {
           success: true,
           data: {
-            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: false },
+            preferences: { hideSignatureOutline: false, hideSignatureHash: false, lockedFieldsBackground: false, allowDownloadBeforeSigning: true },
           },
         };
         MockedHttpClient.prototype.patch = jest.fn().mockResolvedValue(mockResponse);
@@ -284,6 +284,7 @@ describe("TurboPartner Module", () => {
         const result = await TurboPartner.updateOrganizationPreferences("org-1", { lockedFieldsBackground: false });
 
         expect(result.data.preferences.lockedFieldsBackground).toBe(false);
+        expect(result.data.preferences.allowDownloadBeforeSigning).toBe(true);
         // The request body wraps the partial preferences under a `preferences` key,
         // matching the backend PATCH contract. Only the given key is sent.
         expect(MockedHttpClient.prototype.patch).toHaveBeenCalledWith(

--- a/packages/php-sdk/README.md
+++ b/packages/php-sdk/README.md
@@ -910,6 +910,7 @@ $prefs = TurboPartner::getOrganizationPreferences('org-uuid-here')->preferences;
 var_dump($prefs->hideSignatureOutline);   // false by default
 var_dump($prefs->hideSignatureHash);      // false by default
 var_dump($prefs->lockedFieldsBackground); // true by default
+var_dump($prefs->allowDownloadBeforeSigning); // false by default
 ```
 
 #### `updateOrganizationPreferences()`
@@ -929,6 +930,7 @@ var_dump($result->preferences->lockedFieldsBackground); // false
 | `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+| `allowDownloadBeforeSigning` | `false` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 #### `deleteOrganization()`
 

--- a/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
+++ b/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
@@ -11,9 +11,10 @@ namespace TurboDocx\Types\Partner;
 final class PartnerOrgPreferences implements \JsonSerializable
 {
     // Defaults mirror the backend's PARTNER_PREFERENCE_DEFAULTS: the two "hide" flags
-    // are off, the locked-fields grey box is on. The API always sends all three keys,
-    // so these only surface on a hand-built instance or a truncated response -- but a
-    // `false` here would misreport the platform default for lockedFieldsBackground.
+    // and the download-before-signing flag are off, the locked-fields grey box is on. The
+    // API always sends all four keys, so these only surface on a hand-built instance or a
+    // truncated response -- but a `false` here would misreport the platform default for
+    // lockedFieldsBackground.
     public function __construct(
         public readonly bool $hideSignatureOutline = false,
         public readonly bool $hideSignatureHash = false,

--- a/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
+++ b/packages/php-sdk/src/Types/Partner/PartnerOrgPreferences.php
@@ -18,6 +18,10 @@ final class PartnerOrgPreferences implements \JsonSerializable
         public readonly bool $hideSignatureOutline = false,
         public readonly bool $hideSignatureHash = false,
         public readonly bool $lockedFieldsBackground = true,
+        // When enabled, a signer can download the unsigned PDF from the signing
+        // page before they sign it (for example, to review it with their legal
+        // team). Defaults to off.
+        public readonly bool $allowDownloadBeforeSigning = false,
     ) {}
 
     /**
@@ -30,6 +34,7 @@ final class PartnerOrgPreferences implements \JsonSerializable
             hideSignatureOutline: (bool) ($data['hideSignatureOutline'] ?? false),
             hideSignatureHash: (bool) ($data['hideSignatureHash'] ?? false),
             lockedFieldsBackground: (bool) ($data['lockedFieldsBackground'] ?? true),
+            allowDownloadBeforeSigning: (bool) ($data['allowDownloadBeforeSigning'] ?? false),
         );
     }
 
@@ -42,6 +47,7 @@ final class PartnerOrgPreferences implements \JsonSerializable
             'hideSignatureOutline' => $this->hideSignatureOutline,
             'hideSignatureHash' => $this->hideSignatureHash,
             'lockedFieldsBackground' => $this->lockedFieldsBackground,
+            'allowDownloadBeforeSigning' => $this->allowDownloadBeforeSigning,
         ];
     }
 

--- a/packages/php-sdk/tests/Unit/TurboPartnerPreferencesTest.php
+++ b/packages/php-sdk/tests/Unit/TurboPartnerPreferencesTest.php
@@ -102,6 +102,7 @@ final class TurboPartnerPreferencesTest extends TestCase
                     'hideSignatureOutline' => false,
                     'hideSignatureHash' => false,
                     'lockedFieldsBackground' => true,
+                    'allowDownloadBeforeSigning' => false,
                 ],
             ],
         ]) ?: '');
@@ -110,6 +111,7 @@ final class TurboPartnerPreferencesTest extends TestCase
 
         $this->assertTrue($result->preferences->lockedFieldsBackground);
         $this->assertFalse($result->preferences->hideSignatureOutline);
+        $this->assertFalse($result->preferences->allowDownloadBeforeSigning);
 
         $request = $this->lastRequest();
         $this->assertSame('GET', $request->getMethod());
@@ -128,6 +130,7 @@ final class TurboPartnerPreferencesTest extends TestCase
                     'hideSignatureOutline' => false,
                     'hideSignatureHash' => false,
                     'lockedFieldsBackground' => false,
+                    'allowDownloadBeforeSigning' => false,
                 ],
             ],
         ]) ?: '');

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -461,7 +461,7 @@ await TurboPartner.delete_organization(org_id)
 | `hideSignatureOutline` | `False` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `False` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `True` | Grey box behind locked fields (`False` = plain text) |
-| `allowDownloadBeforeSigning` | `False` | Let a signer download the unsigned PDF from the signing page before they sign (e.g. to review it with their legal team) |
+| `allowDownloadBeforeSigning` | `False` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 #### Organization User & API Key Management
 

--- a/packages/py-sdk/README.md
+++ b/packages/py-sdk/README.md
@@ -447,7 +447,7 @@ print(prefs["lockedFieldsBackground"])  # True by default
 # Update them — pass only the keys you want to change; every other organization
 # setting is preserved. Keys stay camelCase: they are the API contract.
 await TurboPartner.update_organization_preferences(
-    org_id, {"lockedFieldsBackground": False}
+    org_id, {"lockedFieldsBackground": False, "allowDownloadBeforeSigning": True}
 )
 
 # Delete organization
@@ -461,6 +461,7 @@ await TurboPartner.delete_organization(org_id)
 | `hideSignatureOutline` | `False` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `False` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `True` | Grey box behind locked fields (`False` = plain text) |
+| `allowDownloadBeforeSigning` | `False` | Let a signer download the unsigned PDF from the signing page before they sign (e.g. to review it with their legal team) |
 
 #### Organization User & API Key Management
 

--- a/packages/py-sdk/src/turbodocx_sdk/modules/partner.py
+++ b/packages/py-sdk/src/turbodocx_sdk/modules/partner.py
@@ -261,7 +261,7 @@ class TurboPartner:
 
         Returns:
             Dict with success and data (preferences: hideSignatureOutline,
-            hideSignatureHash, lockedFieldsBackground)
+            hideSignatureHash, lockedFieldsBackground, allowDownloadBeforeSigning)
         """
         client = cls._get_client()
         return await client.get(
@@ -285,7 +285,8 @@ class TurboPartner:
         Args:
             organization_id: Organization UUID
             preferences: The preference keys to change (camelCase), e.g.
-                hideSignatureOutline, hideSignatureHash, lockedFieldsBackground
+                hideSignatureOutline, hideSignatureHash, lockedFieldsBackground,
+                allowDownloadBeforeSigning
 
         Returns:
             Dict with success and data (updated preferences)

--- a/packages/py-sdk/tests/test_turbopartner.py
+++ b/packages/py-sdk/tests/test_turbopartner.py
@@ -352,7 +352,8 @@ class TestGetOrganizationPreferences:
                 "preferences": {
                     "hideSignatureOutline": False,
                     "hideSignatureHash": False,
-                    "lockedFieldsBackground": True
+                    "lockedFieldsBackground": True,
+                    "allowDownloadBeforeSigning": False
                 }
             }
         }
@@ -384,7 +385,8 @@ class TestUpdateOrganizationPreferences:
                 "preferences": {
                     "hideSignatureOutline": False,
                     "hideSignatureHash": False,
-                    "lockedFieldsBackground": False
+                    "lockedFieldsBackground": False,
+                    "allowDownloadBeforeSigning": True
                 }
             }
         }
@@ -400,6 +402,7 @@ class TestUpdateOrganizationPreferences:
             )
 
             assert result["data"]["preferences"]["lockedFieldsBackground"] is False
+            assert result["data"]["preferences"]["allowDownloadBeforeSigning"] is True
             # Only the given key, wrapped in a camelCase-verbatim "preferences" body
             mock_client.patch.assert_called_once_with(
                 f"/partner/{PARTNER_ID}/organizations/org-123/preferences",

--- a/packages/ruby-sdk/README.md
+++ b/packages/ruby-sdk/README.md
@@ -527,6 +527,7 @@ TurboDocxSdk::TurboPartner.update_organization_preferences("org-uuid",
 | `hideSignatureOutline` | `false` | Hide the outline/label drawn around signed fields |
 | `hideSignatureHash` | `false` | Hide the verification hash printed on signed fields |
 | `lockedFieldsBackground` | `true` | Grey box behind locked fields (`false` = plain text) |
+| `allowDownloadBeforeSigning` | `false` | When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). Defaults to off. |
 
 #### Organization User Management
 

--- a/packages/ruby-sdk/lib/turbodocx_sdk/turbo_partner.rb
+++ b/packages/ruby-sdk/lib/turbodocx_sdk/turbo_partner.rb
@@ -115,7 +115,8 @@ module TurboDocxSdk
       #
       # @param organization_id [String]
       # @return [Hash] the organization's partner-settable preferences under +data.preferences+
-      #   (+hideSignatureOutline+, +hideSignatureHash+, +lockedFieldsBackground+ booleans)
+      #   (+hideSignatureOutline+, +hideSignatureHash+, +lockedFieldsBackground+,
+      #   +allowDownloadBeforeSigning+ booleans)
       # @raise [NotFoundError] if the organization does not exist
       # @raise [AuthenticationError] on invalid credentials
       # @raise [NetworkError] on connection failure
@@ -128,7 +129,8 @@ module TurboDocxSdk
       #
       # Pass only the keys you want to change; each must be a boolean. The keys stay
       # camelCase verbatim (+hideSignatureOutline+, +hideSignatureHash+,
-      # +lockedFieldsBackground+) -- they are the API contract, not Ruby names.
+      # +lockedFieldsBackground+, +allowDownloadBeforeSigning+) -- they are the API
+      # contract, not Ruby names.
       #
       # @param organization_id [String]
       # @param preferences [Hash] the preference keys to change (only these are sent)

--- a/packages/ruby-sdk/spec/turbo_partner_spec.rb
+++ b/packages/ruby-sdk/spec/turbo_partner_spec.rb
@@ -230,7 +230,8 @@ RSpec.describe TurboDocxSdk::TurboPartner do
             "preferences" => {
               "hideSignatureOutline" => false,
               "hideSignatureHash" => false,
-              "lockedFieldsBackground" => true
+              "lockedFieldsBackground" => true,
+              "allowDownloadBeforeSigning" => false
             }
           }
         }
@@ -240,6 +241,7 @@ RSpec.describe TurboDocxSdk::TurboPartner do
 
         expect(result["data"]["preferences"]["lockedFieldsBackground"]).to eq(true)
         expect(result["data"]["preferences"]["hideSignatureOutline"]).to eq(false)
+        expect(result["data"]["preferences"]["allowDownloadBeforeSigning"]).to eq(false)
         expect(mock_client).to have_received(:get).with(
           "/partner/#{partner_id}/organizations/org-1/preferences"
         )
@@ -254,7 +256,8 @@ RSpec.describe TurboDocxSdk::TurboPartner do
             "preferences" => {
               "hideSignatureOutline" => false,
               "hideSignatureHash" => false,
-              "lockedFieldsBackground" => false
+              "lockedFieldsBackground" => false,
+              "allowDownloadBeforeSigning" => false
             }
           }
         }


### PR DESCRIPTION
## Summary
Adds `allowDownloadBeforeSigning`, a new partner-settable organization preference, across all six SDKs — mirroring the existing display-preference fields (`hideSignatureOutline`, `hideSignatureHash`, `lockedFieldsBackground`).

When enabled, a signer can download the unsigned PDF from the signing page before they sign it (for example, to review it with their legal team). It is **opt-in — defaults to off** — so an org that never enables it is unaffected.

## Changes
- `PartnerOrgPreferences` type/model gains the boolean field in every language (wire key stays camelCase `allowDownloadBeforeSigning`)
- READMEs, the `examples/partner-preferences` samples, and per-language tests updated
- The update path still sends only the keys the caller sets (no forced key)

## Change management
- **Type:** additive, backwards-compatible (new optional preference key)
- **Risk:** low — no breaking changes; existing calls unaffected
- **Rollback:** revert this PR
- **Testing:** per-SDK unit suites updated; CI runs all six language suites

## Pre-review checklist
- [ ] Cross-SDK parity maintained (all six languages)
- [ ] Default is off (opt-in)
- [ ] No breaking changes
